### PR TITLE
Bump requests to 2.33.0 and pytest to 9.0.3 (security)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,7 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+
+# Claude / AI tooling
+.claude/
+docs/superpowers/

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -47,12 +47,12 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "cryptography==46.0.7",
-    "requests==2.32.4"
+    "requests==2.33.0"
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest==8.4.1",
+    "pytest==9.0.3",
     "pytest-cov==6.2.1",
     "ruff==0.12.4",
     "bandit==1.8.6",

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 cryptography==46.0.7
-requests==2.32.4
-pytest==7.4.4
+requests==2.33.0
+pytest==9.0.3
 ruff==0.8.4
 bandit==1.8.0

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -6,5 +6,5 @@ aiofiles==23.2.1
 python-jose[cryptography]==3.4.0
 passlib[bcrypt]==1.7.4
 python-dotenv==1.2.2
-requests==2.32.4
+requests==2.33.0
 cryptography==46.0.7


### PR DESCRIPTION
## Summary
- Bumps **requests** from 2.32.4 to 2.33.0 in /python (both files) and /server — CVE for insecure temp file reuse in \`extract_zipped_paths()\` (alerts #35, #33, #34)
- Bumps **pytest** in /python from 7.4.4 (requirements.txt) and 8.4.1 (pyproject.toml dev extras) to 9.0.3 — fixes vulnerable tmpdir handling (alert #43)

Resolves the three remaining Dependabot alerts not covered by automated PRs after the initial sweep. Supersedes #16 (which conflicted after sibling /server bumps merged).

## Notes
- pytest 9.x requires Python >=3.10. CI runs on 3.11 so this is safe.
- The \`test\` optional-dependency extra in \`pyproject.toml\` retains \`pytest>=7.4.0\` so end users on older Python who only pull the test extra are unaffected.
- Verified locally: 148 python tests pass with the updated stack.

## Test plan
- [x] Local: \`pip install -r python/requirements.txt && pip install -e python && pytest python/tests/\` — 148 passed
- [x] Server smoke: imports + FastAPI app loads with cryptography 46.0.7, requests 2.33.0, python-multipart 0.0.26, python-dotenv 1.2.2