### PR TITLE
Bump black to 26.3.1 (security)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -57,7 +57,7 @@ dev = [
     "ruff==0.12.4",
     "bandit==1.8.6",
     "mypy==1.17.0",
-    "black==24.10.0"
+    "black==26.3.1"
 ]
 test = [
     "pytest>=7.4.0",


### PR DESCRIPTION
## Summary
- Bumps **black** from 24.10.0 to 26.3.1 in /python dev extras — fixes arbitrary file writes from unsanitized user input in cache file name (Dependabot alert #57, high severity)

## Notes
- black 26.3.1 requires Python >=3.10; dev tooling is already aligned with pytest 9.0.3 which has the same constraint.

## Test plan
- [x] \`pip install black==26.3.1\` succeeds and \`import black\` works