### PR TITLE
v1.4-alpha.1: signature expiration + DNS TXT cross-verification (Rust)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to the SchemaPin project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0-alpha.1] - 2026-04-30
+
+### Added
+
+#### Signature Expiration (`expires_at`) — Rust
+
+- **`SkillSignature::expires_at`**: Optional ISO 8601 / RFC 3339 timestamp on `.schemapin.sig` documents. v1.3 verifiers ignore the field; v1.4 verifiers degrade expired signatures to a warning rather than failing.
+- **`SignOptions` builder** (`SignOptions::new().with_expires_in(Duration::days(N))`): Optional sign-time configuration. Wraps the existing `sign_skill` parameters and adds `expires_in`. The legacy `sign_skill` function delegates to `sign_skill_with_options` for backward compatibility.
+- **`VerificationResult::expired`** + **`VerificationResult::expires_at`**: Surface expiration state on the result. `valid` remains `true` for expired signatures (degraded, not failed), and a `signature_expired` warning is appended.
+- **`VerificationResult::with_expiration_check`**: Helper applied automatically by `verify_skill_offline` after a successful signature check. Unparseable timestamps emit a `signature_expires_at_unparseable` warning rather than failing closed.
+- Documents written by `sign_skill_with_options` with `expires_in` set advertise `schemapin_version: "1.4"`; documents without `expires_at` retain `"1.3"`.
+
+#### DNS TXT Cross-Verification — Rust
+
+- **New `dns` module** with `DnsTxtRecord`, `parse_txt_record`, `verify_dns_match`, and `txt_record_name`. Always available; the parser/matcher have no DNS dependencies.
+- **`fetch_dns_txt(domain)`**: Async lookup behind the new `dns` Cargo feature. Brings in `hickory-resolver`, `tokio`, and `async-trait`.
+- **`verify_skill_offline_with_dns(...)`**: Variant of `verify_skill_offline` that accepts an optional `&DnsTxtRecord`. A mismatching record converts the result into a hard `DOMAIN_MISMATCH` failure; an absent record is a no-op (DNS TXT is additive).
+- **TXT record format**: `_schemapin.{domain}` IN TXT `"v=schemapin1; kid=...; fp=sha256:..."`. Whitespace-tolerant parser, case-insensitive on `fp`, ignores unknown fields for forward compatibility.
+
+#### Specification Updates (v1.4)
+
+- **Section 16**: Signature Expiration — `expires_at` field, degraded-vs-failed semantics, backward compatibility.
+- **Section 17**: DNS TXT Cross-Verification — `_schemapin.{domain}` TXT record format, verifier semantics, lookup name construction.
+- **Section 12**: Updated version compatibility note for v1.4.
+
+### Changed
+
+- Rust crate version: `1.3.0` → `1.4.0-alpha.1`.
+- `sign_skill` now formats `signed_at` with second-level precision and a `Z` UTC suffix (RFC 3339 `SecondsFormat::Secs`). Existing v1.3 signatures continue to verify; the change only affects newly minted signatures.
+
+### Notes
+
+- This is the first v1.4 alpha. Python, JavaScript, and Go implementations follow in subsequent alphas before the v1.4.0 release.
+- Both new features are additive optional fields/records — v1.3 clients are unaffected.
+
 ## [1.3.0] - 2026-02-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ SchemaPin lets tool developers sign their schemas and skill folders with ECDSA P
 - **ECDSA P-256 + SHA-256** cryptographic signatures
 - **`.well-known` discovery** for public keys (RFC 8615)
 - **TOFU key pinning** to prevent key substitution attacks
-- **Key revocation** with standalone revocation documents
+- **Key revocation** with standalone signed revocation documents and structured reasons
 - **Trust bundles** for offline and air-gapped verification
 - **Pluggable resolvers** — `.well-known`, local file, trust bundle, or chain
 - **Skill folder signing** for AgentSkills (SKILL.md + file manifests)
 - **Cross-language** — Python, JavaScript, Go, and Rust implementations
+
+> **v1.4.0-alpha.1** (Rust only — preview): optional [signature expiration (`expires_at`)](https://docs.schemapin.org/signature-expiration/) with degraded-not-failed verification, and optional [DNS TXT cross-verification](https://docs.schemapin.org/dns-txt/) at `_schemapin.{domain}` for second-channel trust. Both are additive optional fields/records — v1.3 verifiers ignore them, v1.4 verifiers handle both. Python, JavaScript, and Go ports follow in subsequent alphas before the v1.4.0 release.
 
 ## Quick Start
 
@@ -60,6 +62,9 @@ go install github.com/ThirdKeyAi/schemapin/go/cmd/...@latest
 ```toml
 [dependencies]
 schemapin = "1.3.0"
+# v1.4.0-alpha.1 is also published — opt in for signature expiration
+# and DNS TXT cross-verification:
+# schemapin = { version = "1.4.0-alpha.1", features = ["dns"] }
 ```
 
 ## Documentation
@@ -70,6 +75,9 @@ schemapin = "1.3.0"
 | API Reference | [docs.schemapin.org/api-reference](https://docs.schemapin.org/api-reference/) |
 | Skill Signing | [docs.schemapin.org/skill-signing](https://docs.schemapin.org/skill-signing/) |
 | Trust Bundles | [docs.schemapin.org/trust-bundles](https://docs.schemapin.org/trust-bundles/) |
+| Revocation | [docs.schemapin.org/revocation](https://docs.schemapin.org/revocation/) |
+| Signature Expiration *(v1.4-alpha, Rust)* | [docs.schemapin.org/signature-expiration](https://docs.schemapin.org/signature-expiration/) |
+| DNS TXT Cross-Verification *(v1.4-alpha, Rust)* | [docs.schemapin.org/dns-txt](https://docs.schemapin.org/dns-txt/) |
 | Deployment | [docs.schemapin.org/deployment](https://docs.schemapin.org/deployment/) |
 | Troubleshooting | [docs.schemapin.org/troubleshooting](https://docs.schemapin.org/troubleshooting/) |
 | Technical Specification | [TECHNICAL_SPECIFICATION.md](TECHNICAL_SPECIFICATION.md) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,7 +16,8 @@
 | **1.1.0** | 2026-01 | Revocation documents, standalone revocation endpoint | Shipped |
 | **1.2.0** | 2026-02 | Offline verification, trust bundles, resolver abstraction | Shipped |
 | **1.3.0** | 2026-02 | AgentSkills security — skill folder signing | **Shipped** |
-| **1.4.0** | Q2-Q3 2026 | Signature lifecycle, version binding, A2A trust | Planning |
+| **1.4.0-alpha.1** | 2026-04-30 | Signature expiration + DNS TXT cross-verification (Rust) | **Shipped** |
+| **1.4.0** | Q2-Q3 2026 | Signature lifecycle, version binding, A2A trust | In progress |
 | **1.5.0** | Q4 2026 | Multi-key endorsement, permissions, advanced revocation | Planning |
 
 ---
@@ -96,7 +97,7 @@ The existing `.well-known/schemapin.json` discovery, TOFU key pinning database, 
 
 All v1.4 additions are optional fields — fully backward compatible with v1.3 clients.
 
-### Signature Expiration / TTL
+### Signature Expiration / TTL — **Rust shipped (alpha.1)**
 
 Right now, a signature is valid forever once created. There's a `signed_at` timestamp but no `expires_at`. A signature from 2 years ago on an abandoned tool is just as "valid" as one from yesterday — there's no forcing function for developers to re-sign after security reviews, and clients can't distinguish "actively maintained" from "signed once and forgotten."
 
@@ -127,7 +128,7 @@ SchemaPin signs a schema at a point in time, but there's no concept of "this is 
 
 No new crypto required — just metadata. The hash chain is lightweight and elegant.
 
-### DNS TXT Cross-Verification
+### DNS TXT Cross-Verification — **Rust shipped (alpha.1)**
 
 AgentPin already uses `_agentpin.{domain}` TXT records, but SchemaPin doesn't leverage DNS yet. Adding a `_schemapin.{domain}` TXT record containing the key fingerprint gives multi-channel verification without requiring a GitHub repo. DNS is controlled through a completely different credential chain than HTTPS hosting, so compromising one doesn't compromise the other.
 
@@ -322,4 +323,4 @@ We welcome input on roadmap priorities:
 
 ---
 
-*Last updated: 2026-03-01 (cross-repo alignment with AgentPin v0.3.0 AllowedDomains type)*
+*Last updated: 2026-04-30 (v1.4.0-alpha.1 — Rust signature expiration + DNS TXT cross-verification)*

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: schemapin
 title: SchemaPin
-description: Cryptographic tool schema verification to prevent MCP Rug Pull attacks — ECDSA P-256 signing, SHA-256 hashing, TOFU key pinning, and .well-known discovery
-version: 1.3.0
+description: Cryptographic tool schema verification to prevent MCP Rug Pull attacks — ECDSA P-256 signing, SHA-256 hashing, TOFU key pinning, .well-known discovery, signed revocation documents, and (v1.4-alpha, Rust) signature expiration plus DNS TXT cross-verification
+version: 1.4.0-alpha.1
+stable_version: 1.3.0
 ---
 
 # SchemaPin Development Skills Guide
@@ -164,15 +165,24 @@ result = verify_schema_offline(
 
 ### Standalone Revocation Documents
 
+Full guide with operational playbook, all four languages, and combined inline+standalone semantics: **[docs/revocation.md](docs/revocation.md)**.
+
 ```python
 from schemapin.revocation import (
     build_revocation_document, add_revoked_key,
-    check_revocation, RevocationReason
+    check_revocation, check_revocation_combined, RevocationReason
 )
 
 doc = build_revocation_document("example.com")
 add_revoked_key(doc, fingerprint, RevocationReason.KEY_COMPROMISE)
 check_revocation(doc, some_fingerprint)  # raises if revoked
+
+# In production, always use combined check (inline list + standalone doc):
+check_revocation_combined(
+    revoked_keys_list=discovery.revoked_keys,
+    revocation_doc=doc,
+    fingerprint=some_fingerprint,
+)
 ```
 
 ### Trust Bundles (Offline / Air-Gapped)
@@ -286,6 +296,64 @@ _, current_manifest = canonicalize_skill("./my-skill/")
 tampered = detect_tampered_files(current_manifest, sig.file_manifest)
 # tampered.modified, tampered.added, tampered.removed
 ```
+
+---
+
+## v1.4.0-alpha.1 Features (Rust only — preview)
+
+Both features are **additive optional fields/records**: v1.3 verifiers ignore them, and v1.4 signatures without these fields behave identically to v1.3. Python, JavaScript, and Go ports follow in subsequent alphas before the v1.4.0 release.
+
+### Signature Expiration (`expires_at`)
+
+Optional ISO 8601 / RFC 3339 timestamp on `.schemapin.sig`. Verifiers past the timestamp degrade the result (warning) instead of failing — `valid` stays `true`, `expired` becomes `true`, and a `signature_expired` warning is appended.
+
+```rust
+use schemapin::skill::{sign_skill_with_options, SignOptions, verify_skill_offline};
+
+// Sign with a 180-day TTL — writes expires_at into .schemapin.sig
+let opts = SignOptions::new().with_expires_in(chrono::Duration::days(180));
+let sig = sign_skill_with_options(dir, &priv_pem, "example.com", opts)?;
+
+// Verify — past expires_at returns valid=true with expired=true and a
+// "signature_expired" warning, never a hard failure
+let result = verify_skill_offline(dir, &discovery, None, None, None, Some("tool"));
+if result.expired {
+    log::warn!("signature past {}", result.expires_at.unwrap_or_default());
+}
+```
+
+`SignOptions` is a builder; the legacy `sign_skill(...)` function is preserved for v1.3 callers and writes signatures without `expires_at` (still advertised as `schemapin_version: "1.3"`).
+
+### DNS TXT Cross-Verification (`_schemapin.{domain}`)
+
+Tool providers MAY publish a TXT record alongside `.well-known/schemapin.json`:
+
+```
+_schemapin.example.com.  IN TXT  "v=schemapin1; kid=acme-2026-04; fp=sha256:a1b2c3..."
+```
+
+Cross-checking the TXT against the discovery key gives a *second-channel* verification — the DNS credential chain is independent of the HTTPS hosting one. Mismatch is a hard failure (`DOMAIN_MISMATCH`); absent record is a no-op.
+
+```rust
+use schemapin::dns::{parse_txt_record, fetch_dns_txt};
+use schemapin::skill::verify_skill_offline_with_dns;
+
+// Parser/matcher are always available
+let txt = parse_txt_record("v=schemapin1; fp=sha256:a1b2c3...")?;
+
+// Async fetch lives behind the `dns` Cargo feature (hickory-resolver)
+#[cfg(feature = "dns")]
+let txt = fetch_dns_txt("example.com").await?;
+
+let result = verify_skill_offline_with_dns(
+    dir, &discovery, None, None, None, Some("tool"), txt.as_ref(),
+);
+```
+
+| Cargo feature | Default | Brings in |
+|---------------|---------|-----------|
+| `fetch` | off | `reqwest`, `tokio`, `async-trait` |
+| `dns` *(NEW)* | off | `hickory-resolver`, `tokio`, `async-trait` |
 
 ---
 

--- a/TECHNICAL_SPECIFICATION.md
+++ b/TECHNICAL_SPECIFICATION.md
@@ -232,8 +232,8 @@ Implementations MUST handle the following error conditions gracefully:
 
 ### **12. Version Compatibility**
 
-- **Schema Version:** This specification is version 1.2. The `schema_version` field in `.well-known` files indicates compatibility.
-- **Backward Compatibility:** Version 1.2 clients MUST support version 1.0 and 1.1 endpoints for backward compatibility. The `revocation_endpoint`, `contact`, and standalone revocation document fields are all optional and additive.
+- **Schema Version:** This specification is version 1.4. The `schema_version` field in `.well-known` files indicates compatibility.
+- **Backward Compatibility:** Version 1.4 clients MUST support version 1.0–1.3 endpoints for backward compatibility. The `revocation_endpoint`, `contact`, standalone revocation document, `expires_at`, and `_schemapin.{domain}` TXT record are all optional and additive.
 - **Future Versions:** Clients SHOULD gracefully handle unknown schema versions by falling back to the highest supported version.
 - **Deprecation Policy:** Any breaking changes will be introduced in new major versions with appropriate migration guidance.
 
@@ -313,3 +313,95 @@ SchemaPin v1.2 defines `verify_schema_offline()` as the core verification primit
 5. **Canonicalize schema** — Apply the canonicalization rules from Section 4 and compute the SHA-256 hash.
 6. **Verify ECDSA signature** — Verify the Base64-encoded signature against the schema hash using the public key.
 7. **Return result** — Return a structured `VerificationResult` with the domain, developer name, key pinning status, and any errors or warnings.
+
+### **16. Signature Expiration (v1.4)**
+
+SchemaPin v1.4 introduces an OPTIONAL `expires_at` field on signature documents (both schema signatures and `.schemapin.sig` for skills).
+
+#### **16.1. Format**
+
+The `expires_at` field is an ISO 8601 / RFC 3339 timestamp in UTC:
+
+```json
+{
+  "schemapin_version": "1.4",
+  "skill_name": "example-skill",
+  "skill_hash": "sha256:...",
+  "signature": "MEUCIQ...",
+  "signed_at": "2026-04-30T12:00:00Z",
+  "expires_at": "2026-10-30T12:00:00Z",
+  "domain": "thirdkey.ai",
+  "signer_kid": "thirdkey-2026-04",
+  "file_manifest": { /* ... */ }
+}
+```
+
+A signature document with `expires_at` MUST set `schemapin_version` to `"1.4"` or higher; documents without `expires_at` MAY retain the v1.3 version string.
+
+#### **16.2. Verifier Semantics**
+
+When the current time is past `expires_at`, verifiers MUST treat the result as **degraded**, not failed:
+
+- `valid` remains `true` (the cryptographic signature is intact)
+- An `expired: true` flag is set on the result
+- A `signature_expired` warning is appended
+- The `expires_at` value is mirrored on the result for confidence scoring
+
+A degraded result is intended to feed policy decisions: clients MAY refuse to load expired skills, or downgrade them to a lower trust tier, while preserving the ability to inspect signed metadata.
+
+If `expires_at` cannot be parsed as RFC 3339, verifiers MUST emit a `signature_expires_at_unparseable` warning and MUST NOT treat the signature as expired (fail-open on parse, not fail-closed — malformed metadata should not silently invalidate otherwise-valid signatures).
+
+#### **16.3. Backward Compatibility**
+
+- v1.3 verifiers ignore the `expires_at` field entirely; signatures continue to verify.
+- v1.4 signatures without `expires_at` behave identically to v1.3 signatures.
+
+### **17. DNS TXT Cross-Verification (v1.4)**
+
+SchemaPin v1.4 adds an OPTIONAL second-channel verification mechanism via DNS TXT records. The DNS credential chain is independent of the HTTPS hosting credential chain, so an attacker compromising one does not automatically gain control of the other.
+
+#### **17.1. TXT Record Format**
+
+A tool provider MAY publish a TXT record at `_schemapin.{domain}` containing the public-key fingerprint advertised in `.well-known/schemapin.json`:
+
+```
+_schemapin.example.com. IN TXT "v=schemapin1; kid=acme-2026-04; fp=sha256:a1b2c3d4..."
+```
+
+Fields:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `v` | yes | Version tag, currently `schemapin1` |
+| `fp` | yes | Key fingerprint as `sha256:<hex>` (lowercase hex) |
+| `kid` | no | Optional key id, useful for multi-key endpoints (v1.5+) |
+
+Whitespace around `;` and `=` SHOULD be tolerated by parsers. Field order is not significant. Unknown fields MUST be ignored for forward compatibility.
+
+If multiple TXT records exist at the same name, parsers MUST select the first record containing `v=schemapin1`. Multiple TXT chunks within a single record MUST be concatenated in emit order per RFC 1464.
+
+#### **17.2. Verifier Semantics**
+
+| State | Effect |
+|-------|--------|
+| **Absent** | No effect — DNS TXT cross-verification is optional |
+| **Present and matching** | Verification succeeds; absence of mismatch is the trust signal |
+| **Present and mismatching** | Hard failure with `DOMAIN_MISMATCH` error code |
+| **Present and malformed** | Hard failure with `DISCOVERY_INVALID` error code |
+
+The mismatch case is fail-closed because a publishing party that *intentionally* publishes a TXT record has signaled that DNS is part of their trust chain — a divergence between DNS and `.well-known` indicates compromise of one channel.
+
+#### **17.3. Backward Compatibility**
+
+- Verifiers MAY skip DNS TXT lookups entirely (the feature is additive).
+- Tool providers MAY publish or omit the TXT record without affecting v1.3 verifiers.
+- Implementations SHOULD gate DNS resolution behind a feature flag (e.g., the `dns` Cargo feature in Rust) to keep the core library DNS-free.
+
+#### **17.4. Lookup Name Construction**
+
+Implementations MUST strip a single trailing dot from the input domain before constructing the lookup name:
+
+```
+input "example.com"  → "_schemapin.example.com"
+input "example.com." → "_schemapin.example.com"
+```

--- a/context7.json
+++ b/context7.json
@@ -18,6 +18,8 @@
     "docs/skill-signing.md",
     "docs/trust-bundles.md",
     "docs/revocation.md",
+    "docs/signature-expiration.md",
+    "docs/dns-txt.md",
     "docs/deployment.md",
     "docs/troubleshooting.md"
   ],

--- a/context7.json
+++ b/context7.json
@@ -3,7 +3,7 @@
   "url": "https://context7.com/thirdkeyai/schemapin",
   "public_key": "pk_Ehy7QXQTu2Keb0e5BNeyx",
   "projectTitle": "SchemaPin",
-  "description": "Cryptographic tool schema verification to prevent MCP Rug Pull attacks — ECDSA P-256 signing, SHA-256 hashing, TOFU key pinning, and .well-known discovery. Implementations in Python, JavaScript, Rust, and Go. Part of the ThirdKey trust stack.",
+  "description": "Cryptographic tool schema verification to prevent MCP Rug Pull attacks — ECDSA P-256 signing, SHA-256 hashing, TOFU key pinning, .well-known discovery, signed key revocation documents, and (v1.4-alpha, Rust) optional signature expiration plus DNS TXT cross-verification. Stable implementations in Python, JavaScript, Rust, and Go. Part of the ThirdKey trust stack: SchemaPin (tool integrity) → AgentPin (agent identity) → Symbiont (runtime).",
   "folders": [
     "SKILL.md",
     "README.md",
@@ -17,6 +17,7 @@
     "docs/api-reference.md",
     "docs/skill-signing.md",
     "docs/trust-bundles.md",
+    "docs/revocation.md",
     "docs/deployment.md",
     "docs/troubleshooting.md"
   ],
@@ -66,8 +67,12 @@
     "Public key discovery uses RFC 8615 .well-known endpoints: /.well-known/schemapin.json contains developer public keys",
     "Four language implementations with identical verification guarantees: Python (schemapin), JavaScript (schemapin), Rust (schemapin), Go (schemapin)",
     "Core classes: KeyManager (key generation/serialization), SignatureManager (sign/verify), SchemaPinCore (canonicalization), PinningManager (TOFU store)",
-    "Verification flow: canonicalize schema → fetch/resolve public key → verify ECDSA signature → check TOFU pin → return result",
+    "Verification flow: canonicalize schema → fetch/resolve public key → check revocation (inline + standalone) → verify ECDSA signature → TOFU pin → return result",
+    "Revocation: clients MUST honour both the inline `revoked_keys` array on .well-known/schemapin.json AND any standalone signed revocation document at `revocation_endpoint`. Use check_revocation_combined() (or its language equivalent) for production verification — a fingerprint is revoked if it appears in either list. See docs/revocation.md.",
+    "Revocation reasons: `key_compromise` (private key leaked — treat all artifacts as suspect), `superseded` (planned rotation — old artifacts may still be authentic), `cessation_of_operation` (signer no longer operating), `privilege_withdrawn` (signer no longer authorized).",
+    "Key fingerprints are SHA-256 of the DER-encoded SubjectPublicKeyInfo, formatted as `sha256:<lowercase-hex>`. The `sha256:` prefix is required.",
     "Never hardcode or embed private keys — use KeyManager to generate and PEM files for storage",
-    "SchemaPin protects MCP tool schemas from tampering — sign on publish, verify on load"
+    "SchemaPin protects MCP tool schemas from tampering — sign on publish, verify on load",
+    "v1.4.0-alpha.1 (Rust only — preview): optional `expires_at` field on .schemapin.sig (degraded-not-failed semantics — `valid` stays true, `expired` becomes true, `signature_expired` warning appended), and optional `_schemapin.{domain}` DNS TXT record (`v=schemapin1; kid=...; fp=sha256:...`) for second-channel cross-verification (mismatch is hard DOMAIN_MISMATCH; absent is no-op). Both are additive optional fields/records — v1.3 verifiers ignore them. Python, JavaScript, and Go ports follow in subsequent alphas."
   ]
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -358,6 +358,8 @@ result = verify_schema_with_resolver(
 
 ## Revocation
 
+For the rotation playbook, structured reason semantics, and combined inline + standalone checking in production, see the dedicated [Revocation guide](revocation.md). The reference below documents the API surface in each language.
+
 ### Build Revocation Document
 
 #### Python

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -242,36 +242,41 @@ Access-Control-Allow-Methods: GET
 
 ## Key Rotation
 
+> The full rotation playbook — including the standalone signed revocation document format, structured reasons (`key_compromise` / `superseded` / `cessation_of_operation` / `privilege_withdrawn`), and combined inline + standalone semantics — lives in the [Revocation guide](revocation.md). The steps below cover the deployment-side mechanics.
+
 When rotating keys:
 
 1. Generate a new key pair
 2. Update the discovery document with the new public key
-3. Add the old key's SHA-256 fingerprint to `revoked_keys`
+3. Add the old key's SHA-256 fingerprint to `revoked_keys` (and/or to your standalone revocation document at `revocation_endpoint`)
 4. Reduce cache TTL temporarily
 5. Re-sign all published schemas with the new key
 6. Sign skill directories with the new key
 
 ```python
 from schemapin.crypto import KeyManager
+import json
 
 # 1. Generate new key
 new_private, new_public = KeyManager.generate_keypair()
 new_pem = KeyManager.export_public_key_pem(new_public)
 
 # 2. Update discovery document
-import json
 doc = json.load(open(".well-known/schemapin.json"))
+old_pem = doc.get("public_key_pem", "")
 doc["public_key_pem"] = new_pem
 
-# 3. Revoke old key (add fingerprint to revoked_keys)
-import hashlib
-old_pem = doc.get("_previous_key_pem", "")
+# 3. Revoke old key — fingerprint is sha256(DER SubjectPublicKeyInfo),
+#    not sha256 of the PEM text. Use the helper to get it right.
 if old_pem:
-    fingerprint = "sha256:" + hashlib.sha256(old_pem.encode()).hexdigest()
-    doc["revoked_keys"].append(fingerprint)
+    fingerprint = KeyManager.calculate_key_fingerprint(old_pem)  # "sha256:<hex>"
+    doc.setdefault("revoked_keys", []).append(fingerprint)
 
 with open(".well-known/schemapin.json", "w") as f:
     json.dump(doc, f, indent=2)
+
+# 4. (Recommended) Also append the old fingerprint to your standalone
+#    revocation document with a structured reason — see docs/revocation.md.
 ```
 
 ---

--- a/docs/dns-txt.md
+++ b/docs/dns-txt.md
@@ -1,0 +1,228 @@
+# DNS TXT Cross-Verification
+
+> **Status:** v1.4.0-alpha.1 — **Rust only.** Python, JavaScript, and Go ports follow in subsequent alphas before the v1.4.0 release. The wire format is frozen; only the implementations need to catch up.
+
+SchemaPin v1.3 anchors trust in HTTPS: a public key published at `https://example.com/.well-known/schemapin.json`, served over TLS, fingerprinted, and pinned. That works — but it leans on a single credential chain. An attacker with control of the TLS cert, the web origin, or the static-asset bucket can publish a forged discovery document and serve it as if it were the real one.
+
+SchemaPin v1.4 adds an OPTIONAL second-channel verification: a DNS `TXT` record at `_schemapin.{domain}` whose contents include the same public-key fingerprint advertised by the discovery document. DNS is administered through a separate credential chain (registrar account, DNS provider, DNSSEC if deployed) — compromising one channel doesn't automatically compromise the other.
+
+This page covers the Rust API. The other languages follow the same wire format.
+
+---
+
+## TXT record format
+
+```
+_schemapin.example.com.  3600  IN  TXT  "v=schemapin1; kid=acme-2026-04; fp=sha256:a1b2c3d4e5f6..."
+```
+
+Fields:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `v` | yes | Version tag, currently `schemapin1`. Unknown versions are rejected. |
+| `fp` | yes | Key fingerprint as `sha256:<lowercase-hex>`. Must match SchemaPin's fingerprint format (SHA-256 of DER-encoded SubjectPublicKeyInfo). |
+| `kid` | no | Optional key id. Useful for multi-key discovery documents (forward-compat with v1.5). |
+
+**Whitespace** around `;` and `=` is tolerated. **Field order** is not significant. **Unknown fields** are ignored for forward compatibility — a v1.4 parser ignores fields a future v1.5 might add.
+
+If multiple TXT records exist at `_schemapin.{domain}`, the parser selects the first one whose value contains `v=schemapin1`. Multiple TXT chunks within a single record are concatenated in emit order per RFC 1464.
+
+---
+
+## Verifier semantics
+
+| State | Effect |
+|-------|--------|
+| **Absent** (no `_schemapin.{domain}` TXT record) | No effect — DNS TXT is purely additive |
+| **Present and matching** (TXT `fp` equals SHA-256 of `discovery.public_key_pem`) | Verification succeeds; absence of mismatch is the trust signal |
+| **Present and mismatching** | Hard failure with `DOMAIN_MISMATCH` error code |
+| **Present and malformed** (missing `v` or `fp`, wrong `fp` format, unknown version) | Hard failure with `DISCOVERY_INVALID` |
+
+The mismatch case is fail-closed because a publisher who *intentionally* published a TXT record has signaled that DNS is part of their trust chain. A divergence between DNS and `.well-known` indicates compromise of one of the two channels — and there's no way for the verifier to tell which is authentic. Better to refuse than to guess.
+
+---
+
+## Publishing the TXT record
+
+The fingerprint is the SHA-256 of the DER-encoded SubjectPublicKeyInfo, formatted as `sha256:<hex>` — exactly the same fingerprint format SchemaPin uses everywhere else (revocation entries, key ids, TOFU pins).
+
+Compute it from your published PEM:
+
+```bash
+# 1. Compute fingerprint
+FP=$(openssl pkey -pubin -in pubkey.pem -outform DER \
+  | openssl dgst -sha256 -hex \
+  | awk '{print "sha256:" $2}')
+
+# 2. Format the TXT record
+echo "_schemapin.example.com. IN TXT \"v=schemapin1; kid=acme-2026-04; fp=$FP\""
+```
+
+Or programmatically:
+
+```rust
+use schemapin::crypto::calculate_key_id;
+
+let fp = calculate_key_id(&public_key_pem)?;
+let record = format!("v=schemapin1; kid=acme-2026-04; fp={}", fp);
+```
+
+Then publish via your DNS provider's standard TXT record interface. TTL of 3600 (1 hour) is conventional.
+
+### Co-rotation with the discovery document
+
+When you rotate a key, both the `.well-known/schemapin.json` `public_key_pem` AND the `_schemapin.{domain}` TXT record's `fp=` value must change. A divergence between the two — even a transient one during a rotation window — causes verifiers to fail closed on the `DOMAIN_MISMATCH` path. Coordinate the updates:
+
+1. Update the DNS TXT record first; let it propagate (cache TTL).
+2. Update `.well-known/schemapin.json` second.
+3. Verifiers see the new fingerprint in both places, no mismatch fires.
+
+For planned rotations, consider publishing the new record with a `kid=...` distinguishable from the old. v1.5 multi-key endorsement will let you list both keys for an overlap window.
+
+---
+
+## Verifying with DNS cross-check
+
+The Rust API splits this into a parser/matcher (always available, no DNS deps) and an async fetcher (gated behind the `dns` Cargo feature):
+
+### Cargo features
+
+| Feature | Default | Brings in |
+|---------|---------|-----------|
+| `fetch` | off | `reqwest`, `tokio`, `async-trait` |
+| `dns` *(NEW in v1.4)* | off | `hickory-resolver`, `tokio`, `async-trait` |
+
+Enable the feature in your `Cargo.toml`:
+
+```toml
+[dependencies]
+schemapin = { version = "1.4.0-alpha.1", features = ["dns"] }
+```
+
+### Parsing a TXT record
+
+The parser is pure and always available — no DNS dependency:
+
+```rust
+use schemapin::dns::{parse_txt_record, DnsTxtRecord};
+
+let txt: DnsTxtRecord = parse_txt_record(
+    "v=schemapin1; kid=acme-2026-04; fp=sha256:a1b2c3..."
+)?;
+
+assert_eq!(txt.version, "schemapin1");
+assert_eq!(txt.kid.as_deref(), Some("acme-2026-04"));
+assert_eq!(txt.fingerprint, "sha256:a1b2c3...");
+```
+
+This is what you'd use if you were fetching TXT records yourself (some embedded environments) or if your DNS lookup is mediated by another layer.
+
+### Cross-checking against discovery
+
+Once you have a `DnsTxtRecord`, verify it matches the discovery document's key:
+
+```rust
+use schemapin::dns::verify_dns_match;
+
+verify_dns_match(&discovery, &txt)?;  // Err on mismatch
+```
+
+A mismatch returns `Error::Verification { code: DomainMismatch, .. }`.
+
+### Full skill verification with DNS
+
+The high-level helper that ties it all together:
+
+```rust
+use schemapin::skill::verify_skill_offline_with_dns;
+
+let result = verify_skill_offline_with_dns(
+    &skill_dir,
+    &discovery,
+    /* signature_data */ None,
+    revocation.as_ref(),
+    Some(&mut pin_store),
+    /* tool_id */ Some("payments-tool"),
+    /* dns_txt */ Some(&txt),
+);
+
+if !result.valid {
+    // Could be the regular signature/revocation/pin-mismatch failures,
+    // OR a DOMAIN_MISMATCH if dns_txt didn't match the discovery key.
+    return Err(result.error_message.unwrap_or_default().into());
+}
+```
+
+When `dns_txt = None`, `verify_skill_offline_with_dns` behaves identically to `verify_skill_offline` — the cross-check is only applied when a record is provided. This lets callers fail closed on missing TXT (compute `dns_txt` from a successful lookup; treat `Ok(None)` as "no record published, proceed without cross-check") or fail closed on absent records by their own policy (treat `Ok(None)` as a verification failure at the caller layer).
+
+### Async DNS fetch (with `dns` feature)
+
+```rust
+#[cfg(feature = "dns")]
+use schemapin::dns::fetch_dns_txt;
+
+let txt = fetch_dns_txt("example.com").await?;
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//          Ok(Some(record)) — record present and parseable
+//          Ok(None)         — no _schemapin TXT record exists
+//          Err(_)           — DNS resolution error or malformed record
+```
+
+The async fetcher uses `hickory-resolver` (the maintained successor to `trust-dns`). System resolver config is honoured by default; pass a custom config if you need to (e.g., DoH/DoT to avoid eavesdropping or recursive resolver poisoning).
+
+---
+
+## Lookup name construction
+
+```
+input "example.com"   → _schemapin.example.com
+input "example.com."  → _schemapin.example.com   (trailing dot stripped)
+```
+
+Helper:
+
+```rust
+use schemapin::dns::txt_record_name;
+
+assert_eq!(txt_record_name("example.com"),  "_schemapin.example.com");
+assert_eq!(txt_record_name("example.com."), "_schemapin.example.com");
+```
+
+---
+
+## Threat model
+
+DNS TXT cross-verification is most valuable against:
+
+- **HTTPS-origin compromise.** Attacker controls the web origin (compromised hosting account, expired domain not removed from CDN, ACME ownership-validation bypass) but does NOT control the registrar/DNS account. Without DNS cross-check, an attacker-published `.well-known/schemapin.json` would TOFU-pin and verify cleanly. With cross-check, the fingerprint mismatch fails closed.
+- **TLS cert mis-issuance.** A rogue or coerced CA issues a cert for `example.com` to an attacker. Same defense — DNS is on a separate credential chain.
+- **CDN cache-poisoning** for static `.well-known` assets — same shape as origin compromise.
+
+It does NOT defend against:
+
+- **Joint compromise of HTTPS origin + DNS.** If the attacker controls both, they can update both consistently.
+- **Targeted DNS hijack at the verifier.** If the attacker can modify what a specific verifier resolves (rogue resolver, intercepted recursive query), they can fake a matching record. Use DNSSEC, DoH/DoT, or pinned recursive resolvers in high-stakes deployments.
+
+DNS TXT is one defense in a layered posture: TOFU pinning + revocation documents + DNS cross-check + (eventually) v1.5 multi-key endorsement. None of them is sufficient alone.
+
+---
+
+## Backward compatibility
+
+| Verifier ↓ / Publisher → | No TXT published | TXT published, matching | TXT published, mismatching |
+|--------------------------|------------------|--------------------------|------------------------------|
+| **v1.3 verifier** (no DNS check) | works | works | works (check absent) |
+| **v1.4 verifier without `dns_txt`** | works | works | works (check skipped) |
+| **v1.4 verifier with `dns_txt`** | n/a | works | **DOMAIN_MISMATCH** |
+
+Publishing a TXT record never breaks v1.3 verifiers (they don't look). Verifying without `dns_txt` never breaks anything (the cross-check is opt-in). The fail-closed path only fires when both sides have opted in.
+
+---
+
+## See also
+
+- [Technical specification — Section 17](https://github.com/ThirdKeyAI/SchemaPin/blob/main/TECHNICAL_SPECIFICATION.md#17-dns-txt-cross-verification-v14) — normative wire format
+- [Signature expiration](signature-expiration.md) — the other v1.4 feature, also additive
+- [Revocation](revocation.md) — what to do when a key (or your DNS account) is compromised
+- AgentPin uses `_agentpin.{domain}` TXT records on the same pattern; the credential-separation argument is identical.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -361,5 +361,7 @@ const result = verifySkillOffline('./my-skill/', discoveryData, sig, null, pinSt
 - [Skill Signing](skill-signing.md) — SkillSigner deep dive
 - [Trust Bundles](trust-bundles.md) — Offline and air-gapped verification
 - [Revocation](revocation.md) — Rotate keys and serve signed revocation documents
+- [Signature Expiration](signature-expiration.md) — v1.4-alpha (Rust): `expires_at` and degraded-not-failed verification
+- [DNS TXT Cross-Verification](dns-txt.md) — v1.4-alpha (Rust): second-channel `_schemapin.{domain}` lookups
 - [Deployment](deployment.md) — Serve `.well-known` endpoints in production
 - [Troubleshooting](troubleshooting.md) — Common issues and solutions

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -259,6 +259,8 @@ with open(".well-known/schemapin.json", "w") as f:
 }
 ```
 
+The `revoked_keys` array and the `revocation_endpoint` field together let you retire compromised or superseded keys safely. When you rotate, add the old key fingerprint to `revoked_keys` (or to a standalone signed revocation document) — verifiers will fail closed on any pin matching that fingerprint, before they ever attempt signature verification. See the [Revocation guide](revocation.md) for the full operational playbook in all four languages.
+
 ---
 
 ## Step 5: Full Verification Workflow
@@ -358,5 +360,6 @@ const result = verifySkillOffline('./my-skill/', discoveryData, sig, null, pinSt
 - [API Reference](api-reference.md) — Complete API across all 4 languages
 - [Skill Signing](skill-signing.md) — SkillSigner deep dive
 - [Trust Bundles](trust-bundles.md) — Offline and air-gapped verification
+- [Revocation](revocation.md) — Rotate keys and serve signed revocation documents
 - [Deployment](deployment.md) — Serve `.well-known` endpoints in production
 - [Troubleshooting](troubleshooting.md) — Common issues and solutions

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ SchemaPin enables developers to cryptographically sign tool schemas and skill di
 - **Skill Directory Signing** — Sign entire skill directories, producing a `.schemapin.sig` manifest that covers every file
 - **Verification** — Signature verification with public key discovery and TOFU pinning
 - **Trust Bundles** — Offline verification with pluggable discovery resolvers
-- **Revocation** — Key and schema revocation with standalone documents
+- **Key Revocation** — Inline `revoked_keys` plus standalone signed revocation documents with structured reasons. See [Revocation](revocation.md).
 
 ## Quick Examples
 
@@ -76,6 +76,7 @@ All four implementations use identical crypto (ECDSA P-256 + SHA-256) — cross-
 | [API Reference](api-reference.md) | Complete API with function signatures and examples |
 | [Skill Signing](skill-signing.md) | Sign and verify skill directories (v1.3) |
 | [Trust Bundles](trust-bundles.md) | Offline verification and pluggable resolvers |
+| [Revocation](revocation.md) | Rotate keys, publish revocation documents, fail closed |
 | [Deployment](deployment.md) | Serve `.well-known` endpoints in production |
 | [Troubleshooting](troubleshooting.md) | Common issues and solutions |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,6 +77,8 @@ All four implementations use identical crypto (ECDSA P-256 + SHA-256) — cross-
 | [Skill Signing](skill-signing.md) | Sign and verify skill directories (v1.3) |
 | [Trust Bundles](trust-bundles.md) | Offline verification and pluggable resolvers |
 | [Revocation](revocation.md) | Rotate keys, publish revocation documents, fail closed |
+| [Signature Expiration](signature-expiration.md) | `expires_at` field for degraded-not-failed verification (v1.4-alpha, Rust) |
+| [DNS TXT Cross-Verification](dns-txt.md) | Second-channel `_schemapin.{domain}` lookups (v1.4-alpha, Rust) |
 | [Deployment](deployment.md) | Serve `.well-known` endpoints in production |
 | [Troubleshooting](troubleshooting.md) | Common issues and solutions |
 

--- a/docs/revocation.md
+++ b/docs/revocation.md
@@ -1,0 +1,301 @@
+# Revocation
+
+When a private key is compromised, retired, or superseded, you need a way to tell every client that has previously pinned that key to stop trusting it. SchemaPin supports two complementary mechanisms:
+
+1. **Inline `revoked_keys`** — an array on the `.well-known/schemapin.json` discovery document. Cheap, requires no extra endpoint, but only suitable for a handful of revocations.
+2. **Standalone revocation document** — a separate, signed JSON document at a dedicated endpoint. Scales to many revocations, can be cached aggressively, and supports structured reasons. This is the SchemaPin v1.2 approach.
+
+Both mechanisms are checked together — see [Combined revocation checking](#combined-revocation-checking) below.
+
+> **TL;DR**
+> - Compute the SHA-256 fingerprint of the public key you want to revoke.
+> - Add it to either `revoked_keys` in `.well-known/schemapin.json` **or** to a standalone revocation document at a stable URL.
+> - Clients fail closed on any pin matching a revoked fingerprint.
+
+---
+
+## Key fingerprints
+
+Every revocation entry is keyed by the SHA-256 fingerprint of the **DER-encoded SubjectPublicKeyInfo** of the key (the same bytes that sit between the `-----BEGIN PUBLIC KEY-----` / `-----END PUBLIC KEY-----` markers, base64-decoded).
+
+The canonical form is `sha256:<lowercase-hex>`:
+
+```
+sha256:9e2af70c31bb48d65a11e9c47f0add42c4118add370f6eb925e24bf09133ac7a
+```
+
+Compute it from a PEM file:
+
+```bash
+# OpenSSL
+openssl pkey -pubin -in pubkey.pem -outform DER \
+  | openssl dgst -sha256 -hex \
+  | awk '{print "sha256:" $2}'
+```
+
+Or programmatically:
+
+| Language | Helper |
+|----------|--------|
+| Python | `from schemapin.crypto import KeyManager; KeyManager.calculate_key_fingerprint(public_key_pem)` |
+| JavaScript | `import { calculateKeyFingerprint } from 'schemapin'; calculateKeyFingerprint(publicKeyPem)` |
+| Go | `crypto.CalculateKeyID(publicKeyPEM)` |
+| Rust | `schemapin::crypto::calculate_key_id(&public_key_pem)?` |
+
+---
+
+## Mechanism 1: Inline `revoked_keys`
+
+Add the fingerprints to your discovery document. v1.0 clients understand this format.
+
+```json
+{
+  "schema_version": "1.2",
+  "developer_name": "Acme Tools",
+  "public_key_pem": "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----",
+  "revoked_keys": [
+    "sha256:9e2af70c31bb48d65a11e9c47f0add42c4118add370f6eb925e24bf09133ac7a",
+    "sha256:c4118add370f6eb925e24bf09133ac7a9e2af70c31bb48d65a11e9c47f0add42"
+  ],
+  "contact": "security@example.com"
+}
+```
+
+**Use this when**: you have one or two retired keys and don't expect to add many more.
+
+**Don't use this when**: you anticipate dozens of revocations, or you need structured metadata (reason, timestamp). Use a standalone document instead.
+
+---
+
+## Mechanism 2: Standalone Revocation Document (v1.2+)
+
+Publish a separate signed JSON document at a stable URL — typically `/.well-known/schemapin-revocations.json`. Reference it from your discovery document via `revocation_endpoint`:
+
+```json
+{
+  "schema_version": "1.2",
+  "developer_name": "Acme Tools",
+  "public_key_pem": "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----",
+  "revocation_endpoint": "https://example.com/.well-known/schemapin-revocations.json",
+  "contact": "security@example.com"
+}
+```
+
+The revocation document itself looks like this:
+
+```json
+{
+  "schema_version": "1.2",
+  "domain": "example.com",
+  "issued_at": "2026-04-30T08:00:00Z",
+  "revoked_keys": [
+    {
+      "fingerprint": "sha256:9e2af70c31bb48d65a11e9c47f0add42c4118add370f6eb925e24bf09133ac7a",
+      "revoked_at": "2026-03-15T14:22:00Z",
+      "reason": "key_compromise"
+    },
+    {
+      "fingerprint": "sha256:c4118add370f6eb925e24bf09133ac7a9e2af70c31bb48d65a11e9c47f0add42",
+      "revoked_at": "2026-04-01T11:00:00Z",
+      "reason": "superseded"
+    }
+  ]
+}
+```
+
+### Revocation reasons
+
+| Reason | When to use |
+|--------|-------------|
+| `key_compromise` | Private key leaked, stolen, or otherwise exposed. Treat any artifact signed with this key as suspect. |
+| `superseded` | A new key has replaced this one on a planned schedule. The old artifacts may still be authentic. |
+| `cessation_of_operation` | The signer is no longer in operation. No new signatures will be issued. |
+| `privilege_withdrawn` | The signer is no longer authorized to sign for this domain (e.g., contractor offboarded). |
+
+---
+
+## Building and serving a revocation document
+
+### Python
+
+```python
+from schemapin.revocation import (
+    build_revocation_document,
+    add_revoked_key,
+    RevocationReason,
+)
+import json
+
+doc = build_revocation_document("example.com")
+add_revoked_key(
+    doc,
+    "sha256:9e2af70c31bb48d65a11e9c47f0add42c4118add370f6eb925e24bf09133ac7a",
+    RevocationReason.KEY_COMPROMISE,
+)
+
+with open("schemapin-revocations.json", "w") as f:
+    json.dump(doc.to_dict(), f, indent=2)
+```
+
+### JavaScript
+
+```javascript
+import { buildRevocationDocument, addRevokedKey, RevocationReason } from 'schemapin';
+import { writeFileSync } from 'node:fs';
+
+const doc = buildRevocationDocument('example.com');
+addRevokedKey(
+  doc,
+  'sha256:9e2af70c31bb48d65a11e9c47f0add42c4118add370f6eb925e24bf09133ac7a',
+  RevocationReason.KEY_COMPROMISE,
+);
+writeFileSync('schemapin-revocations.json', JSON.stringify(doc, null, 2));
+```
+
+### Go
+
+```go
+import (
+    "encoding/json"
+    "os"
+
+    "github.com/ThirdKeyAi/schemapin/go/pkg/revocation"
+)
+
+doc := revocation.BuildRevocationDocument("example.com")
+revocation.AddRevokedKey(
+    doc,
+    "sha256:9e2af70c31bb48d65a11e9c47f0add42c4118add370f6eb925e24bf09133ac7a",
+    revocation.ReasonKeyCompromise,
+)
+
+data, _ := json.MarshalIndent(doc, "", "  ")
+os.WriteFile("schemapin-revocations.json", data, 0644)
+```
+
+### Rust
+
+```rust
+use schemapin::revocation::{add_revoked_key, build_revocation_document};
+use schemapin::types::revocation::RevocationReason;
+
+let mut doc = build_revocation_document("example.com");
+add_revoked_key(
+    &mut doc,
+    "sha256:9e2af70c31bb48d65a11e9c47f0add42c4118add370f6eb925e24bf09133ac7a",
+    RevocationReason::KeyCompromise,
+);
+
+std::fs::write(
+    "schemapin-revocations.json",
+    serde_json::to_string_pretty(&doc)?,
+)?;
+```
+
+### Hosting
+
+Serve the JSON from the same server that hosts `.well-known/schemapin.json`. Cache aggressively but with a short max-age — see [Deployment guide](deployment.md#cache-control) for recommended `Cache-Control` headers (5 minutes is the conventional value: long enough to absorb traffic spikes, short enough that revocations propagate quickly).
+
+---
+
+## Checking revocation as a verifier
+
+You usually don't call revocation primitives directly — `verify_schema_offline` / `verify_schema_with_resolver` and their skill counterparts do it for you. But the helpers are public for direct inspection:
+
+### Python
+
+```python
+from schemapin.revocation import (
+    check_revocation,            # standalone document
+    check_revocation_combined,   # inline list + standalone document
+    fetch_revocation_document,   # HTTP fetch helper
+)
+
+# Direct check against a single document
+try:
+    check_revocation(rev_doc, fingerprint)
+except KeyRevokedError as e:
+    print(f"key revoked: {e.reason}")
+
+# Combined check (use this in production)
+try:
+    check_revocation_combined(
+        revoked_keys_list=discovery.revoked_keys,
+        revocation_doc=rev_doc,
+        fingerprint=fingerprint,
+    )
+except KeyRevokedError as e:
+    handle_revocation(e)
+```
+
+### Rust
+
+```rust
+use schemapin::revocation::check_revocation_combined;
+use schemapin::error::Error;
+
+match check_revocation_combined(
+    &discovery.revoked_keys,
+    revocation_doc.as_ref(),
+    &fingerprint,
+) {
+    Ok(()) => { /* not revoked */ }
+    Err(Error::Verification { code, message }) if code == ErrorCode::KeyRevoked => {
+        // revoked — fail the verification
+    }
+    Err(other) => return Err(other),
+}
+```
+
+The verification flow inside `verify_schema_offline` checks both mechanisms together, in this order:
+
+1. The fingerprint matches an entry in `discovery.revoked_keys` → `KEY_REVOKED`.
+2. The fingerprint matches a `revoked_keys[].fingerprint` in the standalone document → `KEY_REVOKED`.
+3. Otherwise, continue to TOFU pinning.
+
+A revoked key never reaches the signature-verify step — it fails closed before any cryptographic work happens.
+
+---
+
+## Combined revocation checking
+
+Discovery documents *may* carry both `revoked_keys` (inline) and a `revocation_endpoint` (pointing at a standalone document). Verifiers MUST honour both. The helpers above (`check_revocation_combined` in every language) handle the union semantics: a fingerprint is revoked if it appears in **either** list.
+
+This is also why trust bundles bake in both: an offline bundle stores the inline list with the discovery and fetches the standalone document at bundle-build time so the offline verifier sees the same revocation set as an online one.
+
+---
+
+## Operational playbook
+
+When a key is compromised:
+
+1. **Generate the new key** with `KeyManager.generate_keypair()` (or your language's equivalent) and store the private key in your secret manager. Do not reuse the old key id.
+2. **Sign your active schemas** with the new key. Distribute the new signatures.
+3. **Update `.well-known/schemapin.json`**:
+   - Replace `public_key_pem` with the new public key.
+   - Add the old fingerprint to `revoked_keys` (or add it to your standalone revocation document, ideally both for belt-and-suspenders).
+4. **Bust caches**. Most CDNs honour a `Cache-Control: max-age=300` on the discovery doc; if you need faster propagation, purge the cache directly.
+5. **Notify pinners**. Anyone who has TOFU-pinned the old key will hit a `KEY_REVOKED` error on the next verify and need to re-pin. Communicate the rotation through your usual channels (changelog, status page, security advisory).
+6. **Rebuild trust bundles** if you publish them — see [Trust bundles](trust-bundles.md#bundle-freshness).
+
+When a key is retired (planned rotation, no compromise):
+
+- Same steps, but use `RevocationReason.SUPERSEDED`. Existing artifacts signed with the old key remain authentic; only new signatures should use the new key. Plan a deprecation window before removing the old key from `revoked_keys` (some pinners may take a while to roll forward).
+
+---
+
+## Common mistakes
+
+- **Forgetting the `sha256:` prefix.** Fingerprints in revocation lists must include it. Plain hex is rejected.
+- **Hosting the revocation doc on a different origin.** Most clients fetch with the same TLS posture as discovery; cross-origin fetches can fail silently. Co-locate.
+- **Only revoking inline.** If you have a `revocation_endpoint` published, verifiers will fetch it. Make sure the standalone document is also up to date or remove the field.
+- **Forgetting case sensitivity.** Fingerprints are lowercase hex. SHA-256 helpers in some languages emit uppercase by default — normalise before storing.
+
+---
+
+## See also
+
+- [Trust bundles](trust-bundles.md) — package discovery + revocation for offline verification
+- [Deployment](deployment.md) — serving `.well-known/schemapin-revocations.json` in production
+- [API reference](api-reference.md#revocation) — full revocation API surface in every language
+- [Technical specification — Section 8](https://github.com/ThirdKeyAI/SchemaPin/blob/main/TECHNICAL_SPECIFICATION.md#8-key-revocation) — the normative wire format

--- a/docs/signature-expiration.md
+++ b/docs/signature-expiration.md
@@ -1,0 +1,167 @@
+# Signature Expiration (`expires_at`)
+
+> **Status:** v1.4.0-alpha.1 — **Rust only.** Python, JavaScript, and Go ports follow in subsequent alphas before the v1.4.0 release. The wire format is frozen; only the implementations need to catch up.
+
+A v1.3 signature is valid forever once issued. There's a `signed_at` timestamp on every `.schemapin.sig`, but no expiration — a signature minted two years ago on an abandoned tool reads as "valid" identically to one minted yesterday. There's no forcing function for developers to re-sign after a security review, and verifiers can't distinguish *actively maintained* from *signed once and forgotten*.
+
+SchemaPin v1.4 adds an OPTIONAL `expires_at` field to `.schemapin.sig`. Past the expiration, verifiers **degrade** the result (warning, lower confidence) — they don't fail it. Cryptographically the signature is still intact, so callers retain the ability to inspect signed metadata. What changes is the trust posture: an expired signature feeds policy gating and confidence scoring, not a hard refusal.
+
+This page covers the Rust API. The other languages follow the same wire format.
+
+---
+
+## Wire format
+
+`.schemapin.sig` documents written with an expiration carry an ISO 8601 / RFC 3339 timestamp in the new `expires_at` field, and bump `schemapin_version` to `"1.4"`:
+
+```json
+{
+  "schemapin_version": "1.4",
+  "skill_name": "example-skill",
+  "skill_hash": "sha256:a1b2c3...",
+  "signature": "MEUCIQ...",
+  "signed_at": "2026-04-30T12:00:00Z",
+  "expires_at": "2026-10-30T12:00:00Z",
+  "domain": "thirdkey.ai",
+  "signer_kid": "thirdkey-2026-04",
+  "file_manifest": { /* ... */ }
+}
+```
+
+Documents written WITHOUT `expires_at` continue to advertise `schemapin_version: "1.3"` — full backward compatibility. v1.3 verifiers ignore the field if they encounter it; v1.4 verifiers handle both.
+
+---
+
+## Signing with a TTL
+
+The legacy `sign_skill(...)` is preserved for v1.3 callers. To opt into expiration, use the v1.4 `SignOptions` builder + `sign_skill_with_options`:
+
+```rust
+use schemapin::skill::{sign_skill_with_options, SignOptions};
+use chrono::Duration;
+
+// 180-day TTL
+let opts = SignOptions::new().with_expires_in(Duration::days(180));
+let sig = sign_skill_with_options(
+    &skill_dir,
+    &private_key_pem,
+    "example.com",
+    opts,
+)?;
+
+assert!(sig.expires_at.is_some());
+assert_eq!(sig.schemapin_version, "1.4");
+```
+
+`SignOptions` is also where future v1.4 sign-time options will land (scan-aware fields, schema_version, etc.):
+
+```rust
+let opts = SignOptions::new()
+    .with_signer_kid("acme-2026-04")
+    .with_skill_name("payments-tool")
+    .with_expires_in(Duration::days(90));
+```
+
+---
+
+## Verifier semantics: degraded, not failed
+
+`verify_skill_offline` automatically applies the expiration check after a successful signature verification. The `VerificationResult` gains two new fields:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `valid` | `bool` | Cryptographic signature validity — **unchanged by expiration** |
+| `expired` | `bool` | `true` if `expires_at` is set and now > expires_at |
+| `expires_at` | `Option<String>` | Mirrors the value from the signature when present |
+| `warnings` | `Vec<String>` | Includes `"signature_expired"` when expired |
+
+```rust
+use schemapin::skill::verify_skill_offline;
+
+let result = verify_skill_offline(
+    &skill_dir, &discovery, None, revocation.as_ref(),
+    Some(&mut pin_store), Some("payments-tool"),
+);
+
+if !result.valid {
+    return Err("signature invalid".into());
+}
+
+if result.expired {
+    log::warn!(
+        "skill signature expired at {} — treat as degraded trust",
+        result.expires_at.as_deref().unwrap_or("(unknown)"),
+    );
+    // Policy decision: refuse, downgrade, prompt, or allow with caveat
+}
+```
+
+### Why degrade instead of fail?
+
+A hard fail would create a deployment cliff every time a maintainer misses a renewal — the same UX problem TLS certificate expiry causes. SchemaPin's design choice: surface the staleness, let the policy layer decide. A risk-averse runtime can refuse expired signatures; a permissive one can prompt; a CI pipeline can fail builds when expiration is within a configurable window.
+
+The cryptographic guarantee (this artifact was signed by this key) is unchanged by elapsed time. What changes is the freshness signal that an actively-maintained publisher would re-sign periodically.
+
+### Unparseable timestamps
+
+If `expires_at` is present but cannot be parsed as RFC 3339, the verifier emits a `signature_expires_at_unparseable` warning and treats the signature as **not expired** — fail-open on parse, not fail-closed. Malformed metadata should not silently invalidate otherwise-valid signatures.
+
+```rust
+if result.warnings.iter().any(|w| w == "signature_expires_at_unparseable") {
+    // Log; the publisher's tooling is producing malformed metadata.
+}
+```
+
+---
+
+## Confidence scoring
+
+Together with the existing `signed_at`, `expires_at` enables a simple confidence model:
+
+| Signal | Confidence |
+|--------|------------|
+| `signed_at` recent (< 30 days), `expires_at` distant | high |
+| `signed_at` old, `expires_at` distant | medium |
+| `expires_at` near (< 7 days) | medium-low |
+| `expired = true` | degraded — gate on policy |
+| no `expires_at` (v1.3) | unchanged — assume long-lived |
+
+Implementations that need scoring can compute it from the result:
+
+```rust
+fn confidence(result: &VerificationResult) -> &'static str {
+    if !result.valid { return "invalid"; }
+    if result.expired { return "degraded"; }
+    match result.expires_at.as_deref() {
+        None => "stable",
+        Some(ts) => {
+            let exp = chrono::DateTime::parse_from_rfc3339(ts).ok();
+            let near = exp.map(|t| {
+                t.with_timezone(&chrono::Utc) - chrono::Utc::now()
+                    < chrono::Duration::days(7)
+            }).unwrap_or(false);
+            if near { "expiring_soon" } else { "fresh" }
+        }
+    }
+}
+```
+
+---
+
+## Backward compatibility
+
+| Verifier ↓ / Signature → | v1.3 sig (no `expires_at`) | v1.4 sig (with `expires_at`) |
+|--------------------------|----------------------------|------------------------------|
+| **v1.3 verifier** | works | works (field ignored) |
+| **v1.4 verifier** | works (no expiration applied) | works (degrades when past `expires_at`) |
+
+Both directions are intentional — v1.4 is purely additive. There is no situation where bumping a verifier or a signer to v1.4 breaks an existing deployment.
+
+---
+
+## See also
+
+- [Technical specification — Section 16](https://github.com/ThirdKeyAI/SchemaPin/blob/main/TECHNICAL_SPECIFICATION.md#16-signature-expiration-v14) — normative wire format
+- [DNS TXT cross-verification](dns-txt.md) — the other v1.4 feature, also additive
+- [Skill signing](skill-signing.md) — the v1.3 base this builds on
+- [Revocation](revocation.md) — orthogonal: revocation is hard-fail, expiration is degraded

--- a/docs/skill-signing.md
+++ b/docs/skill-signing.md
@@ -126,7 +126,7 @@ result = verify_skill_offline(
     skill_dir="./my-skill/",
     discovery_data=discovery_doc,
     signature=sig,
-    revocation_doc=None,
+    revocation_doc=None,        # pass a parsed revocation doc to fail closed on revoked keys
     pin_store=KeyPinStore(),
 )
 
@@ -135,6 +135,8 @@ if result.valid:
 else:
     print(f"Verification failed: {result.error}")
 ```
+
+**Pass a `revocation_doc`** to fail closed when a publisher has rotated keys. Skill verification honours the same combined inline + standalone revocation rules as schema verification — see the [Revocation guide](revocation.md) for fetching, parsing, and operational guidance.
 
 #### JavaScript
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -144,6 +144,21 @@ store.remove_pin("example.com")
 # revoked_keys list, the rotation is expected
 ```
 
+### `KEY_REVOKED` error after a fresh fetch
+
+**Problem:** Verification fails with `KEY_REVOKED` even though the discovery document fetched fine and the signature is intact.
+
+**Cause:** The pinned key fingerprint matches an entry in either the discovery document's `revoked_keys` array OR a standalone revocation document at `revocation_endpoint`. SchemaPin fails closed before signature verification — a revoked key never reaches the crypto check.
+
+**Resolution:**
+
+1. **Verify the rotation is legitimate.** Check the publisher's status page, security advisory, or GitHub releases. A `key_compromise` reason on the revocation entry means any artifact signed with that key should be treated as suspect.
+2. **Fetch the new discovery doc.** `.well-known/schemapin.json` will now publish a different `public_key_pem`.
+3. **Remove the old pin** as shown above and re-verify — TOFU re-pins the new key.
+4. **Rebuild any trust bundles** that contained the old discovery — see [Trust bundles](trust-bundles.md#bundle-freshness).
+
+For deeper background on rotation playbooks, structured revocation reasons, and combined inline + standalone checking, see the dedicated [Revocation guide](revocation.md).
+
 ### Lost Pin Store
 
 **Problem:** Pin store file was deleted or corrupted.

--- a/docs/trust-bundles.md
+++ b/docs/trust-bundles.md
@@ -302,7 +302,7 @@ let result = verify_schema_with_resolver(
 
 ## Standalone Revocation Documents
 
-SchemaPin v1.2 also supports standalone revocation documents:
+SchemaPin v1.2 also supports standalone revocation documents. The snippets below cover the bundle-relevant primitives; the full operational guide (rotation playbook, structured reasons, combined inline + standalone semantics, all four languages) lives in **[Revocation](revocation.md)**.
 
 ### Python
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -169,6 +169,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +249,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -327,6 +345,12 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
@@ -424,10 +448,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-proto"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "resolv-conf",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "hmac"
@@ -693,6 +768,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +819,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,10 +837,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "memchr"
@@ -857,6 +969,29 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -984,6 +1119,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,6 +1166,12 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rfc6979"
@@ -1116,12 +1266,13 @@ dependencies = [
 
 [[package]]
 name = "schemapin"
-version = "1.3.0"
+version = "1.4.0-alpha.1"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
  "chrono",
  "hex",
+ "hickory-resolver",
  "p256",
  "rand",
  "reqwest",
@@ -1132,6 +1283,12 @@ dependencies = [
  "thiserror",
  "tokio",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
@@ -1381,6 +1538,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,7 +1651,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1637,6 +1821,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "windows-core"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schemapin"
-version = "1.3.0"
+version = "1.4.0-alpha.1"
 edition = "2021"
 rust-version = "1.70"
 description = "Cryptographic schema integrity verification for AI tools - Rust implementation"
@@ -16,6 +16,7 @@ authors = ["ThirdKey <contact@thirdkey.ai>", "Jascha Wanger <jascha@thirdkey.ai>
 [features]
 default = []
 fetch = ["reqwest", "tokio", "async-trait"]
+dns = ["hickory-resolver", "tokio", "async-trait"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -32,6 +33,9 @@ chrono = { version = "0.4", features = ["serde"] }
 reqwest = { version = "0.12", features = ["json"], optional = true }
 tokio = { version = "1.0", optional = true }
 async-trait = { version = "0.1", optional = true }
+
+# Optional dependency for DNS TXT cross-verification (v1.4)
+hickory-resolver = { version = "0.24", optional = true }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/rust/src/dns.rs
+++ b/rust/src/dns.rs
@@ -1,0 +1,285 @@
+//! DNS TXT cross-verification (v1.4).
+//!
+//! A tool provider MAY publish a TXT record at `_schemapin.{domain}` containing
+//! the public-key fingerprint advertised in `.well-known/schemapin.json`. When
+//! present, clients use it as a *second-channel* verification: the DNS
+//! credential chain is independent of the HTTPS hosting credential chain, so
+//! compromising one doesn't compromise the other.
+//!
+//! ## TXT record format
+//!
+//! ```text
+//! _schemapin.example.com. IN TXT "v=schemapin1; kid=acme-2026-01; fp=sha256:a1b2c3..."
+//! ```
+//!
+//! Fields:
+//! - `v` — version tag (`schemapin1`); required
+//! - `fp` — key fingerprint (`sha256:<hex>`); required, lowercase hex
+//! - `kid` — optional key id, used for disambiguating multi-key endpoints
+//!
+//! ## Verification semantics
+//!
+//! - **Absent record** → no effect (DNS TXT is optional)
+//! - **Present and matching** → confidence boost (recorded in result warnings is *not* used; absence of mismatch is the signal)
+//! - **Present and mismatching** → hard failure with [`crate::error::ErrorCode::DomainMismatch`]
+//!
+//! Use [`parse_txt_record`] to parse a raw TXT string and [`verify_dns_match`]
+//! to cross-check it against a discovery document. With the `dns` feature
+//! enabled, [`fetch_dns_txt`] performs the actual DNS lookup.
+
+use crate::crypto;
+use crate::error::{Error, ErrorCode};
+use crate::types::discovery::WellKnownResponse;
+
+/// Parsed `_schemapin.{domain}` TXT record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DnsTxtRecord {
+    pub version: String,
+    pub kid: Option<String>,
+    /// Lowercase fingerprint string, including the `sha256:` prefix.
+    pub fingerprint: String,
+}
+
+/// Parse a raw TXT record value (e.g. `"v=schemapin1; kid=acme-2026-01; fp=sha256:..."`).
+///
+/// Whitespace around `;` and `=` is tolerated. Field order is not significant.
+/// Returns an error if the record is missing the required `v` or `fp` fields,
+/// or if the version isn't `schemapin1`.
+pub fn parse_txt_record(value: &str) -> Result<DnsTxtRecord, Error> {
+    let mut version: Option<String> = None;
+    let mut kid: Option<String> = None;
+    let mut fp: Option<String> = None;
+
+    for raw_part in value.split(';') {
+        let part = raw_part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let (k, v) = part.split_once('=').ok_or_else(|| Error::Verification {
+            code: ErrorCode::DiscoveryInvalid,
+            message: format!("DNS TXT field missing '=': {}", part),
+        })?;
+        let k = k.trim().to_ascii_lowercase();
+        let v = v.trim();
+        match k.as_str() {
+            "v" => version = Some(v.to_string()),
+            "kid" => kid = Some(v.to_string()),
+            "fp" => fp = Some(v.to_ascii_lowercase()),
+            // Forward-compat: ignore unknown fields rather than reject.
+            _ => {}
+        }
+    }
+
+    let version = version.ok_or_else(|| Error::Verification {
+        code: ErrorCode::DiscoveryInvalid,
+        message: "DNS TXT record missing required 'v' field".to_string(),
+    })?;
+    if version != "schemapin1" {
+        return Err(Error::Verification {
+            code: ErrorCode::DiscoveryInvalid,
+            message: format!("DNS TXT unsupported version: {}", version),
+        });
+    }
+    let fingerprint = fp.ok_or_else(|| Error::Verification {
+        code: ErrorCode::DiscoveryInvalid,
+        message: "DNS TXT record missing required 'fp' field".to_string(),
+    })?;
+    if !fingerprint.starts_with("sha256:") {
+        return Err(Error::Verification {
+            code: ErrorCode::DiscoveryInvalid,
+            message: format!("DNS TXT 'fp' must be sha256:<hex>: {}", fingerprint),
+        });
+    }
+
+    Ok(DnsTxtRecord {
+        version,
+        kid,
+        fingerprint,
+    })
+}
+
+/// Cross-check the DNS TXT record's fingerprint against the discovery document.
+///
+/// Returns `Ok(())` when the fingerprint matches the SHA-256 fingerprint of
+/// the public key in `discovery.public_key_pem`. Returns
+/// [`ErrorCode::DomainMismatch`] otherwise.
+pub fn verify_dns_match(discovery: &WellKnownResponse, txt: &DnsTxtRecord) -> Result<(), Error> {
+    let computed = crypto::calculate_key_id(&discovery.public_key_pem)?.to_ascii_lowercase();
+    if computed == txt.fingerprint {
+        Ok(())
+    } else {
+        Err(Error::Verification {
+            code: ErrorCode::DomainMismatch,
+            message: format!(
+                "DNS TXT fingerprint mismatch: discovery={}, dns={}",
+                computed, txt.fingerprint
+            ),
+        })
+    }
+}
+
+/// Construct the DNS lookup name for a given tool domain.
+pub fn txt_record_name(domain: &str) -> String {
+    format!("_schemapin.{}", domain.trim_end_matches('.'))
+}
+
+/// Fetch and parse the `_schemapin.{domain}` TXT record. Behind the `dns` feature.
+///
+/// Returns:
+/// - `Ok(Some(record))` — record present and parseable
+/// - `Ok(None)` — no `_schemapin` TXT record exists for the domain
+/// - `Err(_)` — DNS resolution error or the record exists but is malformed
+///
+/// Multiple matching TXT chunks are joined per RFC 1464 (concatenation in
+/// emit order). Multiple separate TXT records at the same name are not
+/// supported — the first valid record wins.
+#[cfg(feature = "dns")]
+pub async fn fetch_dns_txt(domain: &str) -> Result<Option<DnsTxtRecord>, Error> {
+    use hickory_resolver::error::ResolveErrorKind;
+    use hickory_resolver::TokioAsyncResolver;
+
+    let name = txt_record_name(domain);
+    let resolver = TokioAsyncResolver::tokio(Default::default(), Default::default());
+    let lookup = match resolver.txt_lookup(&name).await {
+        Ok(l) => l,
+        Err(e) => {
+            if matches!(e.kind(), ResolveErrorKind::NoRecordsFound { .. }) {
+                return Ok(None);
+            }
+            return Err(Error::Verification {
+                code: ErrorCode::DiscoveryFetchFailed,
+                message: format!("DNS TXT lookup failed for {}: {}", name, e),
+            });
+        }
+    };
+
+    for record in lookup.iter() {
+        // hickory yields TxtData as Vec<Box<[u8]>>; concatenate chunks per RFC 1464.
+        let joined: String = record
+            .iter()
+            .map(|chunk| String::from_utf8_lossy(chunk).into_owned())
+            .collect::<Vec<_>>()
+            .join("");
+        if joined.contains("v=schemapin1") {
+            return parse_txt_record(&joined).map(Some);
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::generate_key_pair;
+    use crate::discovery::build_well_known_response;
+
+    #[test]
+    fn test_parse_full_record() {
+        let r = parse_txt_record("v=schemapin1; kid=acme-2026-01; fp=sha256:abcd1234").unwrap();
+        assert_eq!(r.version, "schemapin1");
+        assert_eq!(r.kid.as_deref(), Some("acme-2026-01"));
+        assert_eq!(r.fingerprint, "sha256:abcd1234");
+    }
+
+    #[test]
+    fn test_parse_minimal_record() {
+        let r = parse_txt_record("v=schemapin1;fp=sha256:abc").unwrap();
+        assert_eq!(r.version, "schemapin1");
+        assert_eq!(r.kid, None);
+        assert_eq!(r.fingerprint, "sha256:abc");
+    }
+
+    #[test]
+    fn test_parse_lowercases_fingerprint() {
+        let r = parse_txt_record("v=schemapin1; fp=SHA256:ABCDEF").unwrap();
+        assert_eq!(r.fingerprint, "sha256:abcdef");
+    }
+
+    #[test]
+    fn test_parse_tolerates_whitespace_and_order() {
+        let r = parse_txt_record("  fp = sha256:beef ;  v = schemapin1  ").unwrap();
+        assert_eq!(r.version, "schemapin1");
+        assert_eq!(r.fingerprint, "sha256:beef");
+    }
+
+    #[test]
+    fn test_parse_ignores_unknown_fields() {
+        let r = parse_txt_record("v=schemapin1; fp=sha256:abc; future=ignoreme").unwrap();
+        assert_eq!(r.fingerprint, "sha256:abc");
+    }
+
+    #[test]
+    fn test_parse_missing_v_fails() {
+        let e = parse_txt_record("fp=sha256:abc").unwrap_err();
+        assert!(matches!(
+            e,
+            Error::Verification {
+                code: ErrorCode::DiscoveryInvalid,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_parse_missing_fp_fails() {
+        let e = parse_txt_record("v=schemapin1").unwrap_err();
+        assert!(matches!(
+            e,
+            Error::Verification {
+                code: ErrorCode::DiscoveryInvalid,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_parse_unsupported_version_fails() {
+        assert!(parse_txt_record("v=schemapin99; fp=sha256:abc").is_err());
+    }
+
+    #[test]
+    fn test_parse_fp_without_sha256_prefix_fails() {
+        assert!(parse_txt_record("v=schemapin1; fp=abc").is_err());
+    }
+
+    #[test]
+    fn test_parse_field_without_equals_fails() {
+        assert!(parse_txt_record("v=schemapin1; broken").is_err());
+    }
+
+    #[test]
+    fn test_verify_match() {
+        let kp = generate_key_pair().unwrap();
+        let fp = crypto::calculate_key_id(&kp.public_key_pem).unwrap();
+        let discovery = build_well_known_response(&kp.public_key_pem, None, vec![], "1.4");
+        let txt = DnsTxtRecord {
+            version: "schemapin1".to_string(),
+            kid: None,
+            fingerprint: fp.to_ascii_lowercase(),
+        };
+        verify_dns_match(&discovery, &txt).unwrap();
+    }
+
+    #[test]
+    fn test_verify_mismatch_returns_domain_mismatch() {
+        let kp = generate_key_pair().unwrap();
+        let discovery = build_well_known_response(&kp.public_key_pem, None, vec![], "1.4");
+        let txt = DnsTxtRecord {
+            version: "schemapin1".to_string(),
+            kid: None,
+            fingerprint: "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+                .to_string(),
+        };
+        let err = verify_dns_match(&discovery, &txt).unwrap_err();
+        match err {
+            Error::Verification { code, .. } => assert_eq!(code, ErrorCode::DomainMismatch),
+            other => panic!("unexpected error: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_txt_record_name_strips_trailing_dot() {
+        assert_eq!(txt_record_name("example.com"), "_schemapin.example.com");
+        assert_eq!(txt_record_name("example.com."), "_schemapin.example.com");
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -24,6 +24,9 @@
 //! - `fetch` — Enables HTTP-based discovery (`WellKnownResolver`, `AsyncSchemaResolver`,
 //!   `fetch_well_known`, `fetch_revocation_document`, `verify_schema`). Brings in
 //!   `reqwest`, `tokio`, and `async-trait`.
+//! - `dns` — Enables DNS TXT cross-verification (`dns::fetch_dns_txt`). Brings in
+//!   `hickory-resolver`, `tokio`, and `async-trait`. The DNS parser and matcher
+//!   (`dns::parse_txt_record`, `dns::verify_dns_match`) are always available.
 //!
 //! ## Quick Start
 //!
@@ -74,3 +77,6 @@ pub mod revocation;
 pub mod skill;
 pub mod types;
 pub mod verification;
+
+// New module (v1.4.0): DNS TXT cross-verification
+pub mod dns;

--- a/rust/src/skill.rs
+++ b/rust/src/skill.rs
@@ -23,6 +23,10 @@ use crate::types::revocation::RevocationDocument;
 use crate::verification::{KeyPinningStatus, VerificationResult};
 
 /// Signature metadata written to `.schemapin.sig`.
+///
+/// `expires_at` is an optional v1.4 field. When present, verifiers treat
+/// signatures past the expiration as *degraded* (warning) rather than a
+/// hard failure — see [`verify_skill_offline`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SkillSignature {
     pub schemapin_version: String,
@@ -30,6 +34,8 @@ pub struct SkillSignature {
     pub skill_hash: String,
     pub signature: String,
     pub signed_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
     pub domain: String,
     pub signer_kid: String,
     pub file_manifest: BTreeMap<String, String>,
@@ -179,8 +185,43 @@ pub fn load_signature(skill_dir: &Path) -> Result<SkillSignature, Error> {
     Ok(sig)
 }
 
+/// Optional sign-time parameters for [`sign_skill_with_options`].
+///
+/// Builder-style: all fields default to `None`.
+#[derive(Debug, Default, Clone)]
+pub struct SignOptions<'a> {
+    /// Override the signer key id (KID). Defaults to the discovery fingerprint of the public key.
+    pub signer_kid: Option<&'a str>,
+    /// Override the skill name. Defaults to the SKILL.md frontmatter `name:` or directory basename.
+    pub skill_name: Option<&'a str>,
+    /// Time-to-live for the signature. When set, an `expires_at` field is written.
+    pub expires_in: Option<chrono::Duration>,
+}
+
+impl<'a> SignOptions<'a> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_signer_kid(mut self, kid: &'a str) -> Self {
+        self.signer_kid = Some(kid);
+        self
+    }
+
+    pub fn with_skill_name(mut self, name: &'a str) -> Self {
+        self.skill_name = Some(name);
+        self
+    }
+
+    pub fn with_expires_in(mut self, ttl: chrono::Duration) -> Self {
+        self.expires_in = Some(ttl);
+        self
+    }
+}
+
 /// Sign a skill directory and write `.schemapin.sig`.
 ///
+/// Convenience wrapper over [`sign_skill_with_options`] preserved for v1.3 callers.
 /// Returns the signature document that was written.
 pub fn sign_skill(
     skill_dir: &Path,
@@ -189,17 +230,39 @@ pub fn sign_skill(
     signer_kid: Option<&str>,
     skill_name: Option<&str>,
 ) -> Result<SkillSignature, Error> {
+    sign_skill_with_options(
+        skill_dir,
+        private_key_pem,
+        domain,
+        SignOptions {
+            signer_kid,
+            skill_name,
+            expires_in: None,
+        },
+    )
+}
+
+/// Sign a skill directory with extended options (v1.4+).
+///
+/// When `options.expires_in` is `Some(ttl)`, an `expires_at` ISO 8601 timestamp
+/// is written. Verifiers past that timestamp emit a warning instead of failing
+/// (see [`verify_skill_offline`]).
+pub fn sign_skill_with_options(
+    skill_dir: &Path,
+    private_key_pem: &str,
+    domain: &str,
+    options: SignOptions<'_>,
+) -> Result<SkillSignature, Error> {
     let (root_hash, manifest) = canonicalize_skill(skill_dir)?;
 
-    let name = match skill_name {
+    let name = match options.skill_name {
         Some(n) => n.to_string(),
         None => parse_skill_name(skill_dir),
     };
 
-    let kid = match signer_kid {
+    let kid = match options.signer_kid {
         Some(k) => k.to_string(),
         None => {
-            // Derive public key from private, then compute fingerprint
             let secret = p256::SecretKey::from_pkcs8_pem(private_key_pem)
                 .map_err(|e| Error::Pkcs8(e.to_string()))?;
             let public = secret.public_key();
@@ -213,12 +276,20 @@ pub fn sign_skill(
     let signature_b64 = crypto::sign_data(private_key_pem, &root_hash)?;
     let skill_hash = format!("sha256:{}", hex::encode(Sha256::digest(&root_hash)));
 
+    let now = chrono::Utc::now();
+    let expires_at = options
+        .expires_in
+        .map(|ttl| (now + ttl).to_rfc3339_opts(chrono::SecondsFormat::Secs, true));
+
+    let version = if expires_at.is_some() { "1.4" } else { "1.3" };
+
     let sig_doc = SkillSignature {
-        schemapin_version: "1.3".to_string(),
+        schemapin_version: version.to_string(),
         skill_name: name,
         skill_hash,
         signature: signature_b64,
-        signed_at: chrono::Utc::now().to_rfc3339(),
+        signed_at: now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        expires_at,
         domain: domain.to_string(),
         signer_kid: kid,
         file_manifest: manifest,
@@ -359,6 +430,47 @@ pub fn verify_skill_offline(
     };
 
     VerificationResult::success(&sig.domain, discovery.developer_name.as_deref(), pin_status)
+        .with_expiration_check(sig.expires_at.as_deref())
+}
+
+/// Verify a skill folder offline with an additional DNS TXT cross-check (v1.4).
+///
+/// Behaves identically to [`verify_skill_offline`], then — when `dns_txt` is
+/// `Some` — verifies that the DNS TXT record's fingerprint matches the
+/// discovery key. A mismatch converts the result into a hard failure with
+/// [`ErrorCode::DomainMismatch`]. When `dns_txt` is `None`, behaviour is
+/// unchanged (DNS TXT is an optional, additive trust signal).
+pub fn verify_skill_offline_with_dns(
+    skill_dir: &Path,
+    discovery: &WellKnownResponse,
+    signature_data: Option<&SkillSignature>,
+    revocation_doc: Option<&RevocationDocument>,
+    pin_store: Option<&mut KeyPinStore>,
+    tool_id: Option<&str>,
+    dns_txt: Option<&crate::dns::DnsTxtRecord>,
+) -> VerificationResult {
+    let result = verify_skill_offline(
+        skill_dir,
+        discovery,
+        signature_data,
+        revocation_doc,
+        pin_store,
+        tool_id,
+    );
+
+    if !result.valid {
+        return result;
+    }
+    let Some(txt) = dns_txt else {
+        return result;
+    };
+    match crate::dns::verify_dns_match(discovery, txt) {
+        Ok(()) => result,
+        Err(crate::error::Error::Verification { code, message }) => {
+            VerificationResult::failure(code, &message)
+        }
+        Err(e) => VerificationResult::failure(ErrorCode::DomainMismatch, &e.to_string()),
+    }
 }
 
 /// Resolve discovery via a [`SchemaResolver`], then delegate to
@@ -879,5 +991,175 @@ mod tests {
         );
         assert!(result.valid, "Expected valid, got: {:?}", result);
         assert_eq!(result.domain, Some("example.com".to_string()));
+    }
+
+    // ── v1.4: signature expiration tests ────────────────────────────
+
+    #[test]
+    fn test_sign_with_ttl_writes_expires_at() {
+        let dir = tempdir().unwrap();
+        make_skill_dir(dir.path(), &[("SKILL.md", b"---\nname: ttl\n---\n")]);
+        let kp = generate_key_pair().unwrap();
+        let opts = SignOptions::new().with_expires_in(chrono::Duration::days(30));
+        let sig =
+            sign_skill_with_options(dir.path(), &kp.private_key_pem, "example.com", opts).unwrap();
+        assert!(sig.expires_at.is_some(), "expires_at should be set");
+        assert_eq!(sig.schemapin_version, "1.4");
+        // Round-trip through disk to ensure JSON contains the field.
+        let on_disk = load_signature(dir.path()).unwrap();
+        assert_eq!(on_disk.expires_at, sig.expires_at);
+    }
+
+    #[test]
+    fn test_sign_without_ttl_omits_expires_at() {
+        let dir = tempdir().unwrap();
+        make_skill_dir(dir.path(), &[("SKILL.md", b"---\nname: no-ttl\n---\n")]);
+        let kp = generate_key_pair().unwrap();
+        let sig = sign_skill(dir.path(), &kp.private_key_pem, "example.com", None, None).unwrap();
+        assert!(sig.expires_at.is_none());
+        assert_eq!(sig.schemapin_version, "1.3");
+        let raw = fs::read_to_string(dir.path().join(".schemapin.sig")).unwrap();
+        assert!(!raw.contains("expires_at"), "JSON should omit expires_at");
+    }
+
+    #[test]
+    fn test_verify_with_future_ttl_passes_no_warnings() {
+        let dir = tempdir().unwrap();
+        make_skill_dir(dir.path(), &[("SKILL.md", b"---\nname: future\n---\n")]);
+        let kp = generate_key_pair().unwrap();
+        let opts = SignOptions::new().with_expires_in(chrono::Duration::days(30));
+        sign_skill_with_options(dir.path(), &kp.private_key_pem, "example.com", opts).unwrap();
+
+        let discovery = build_well_known_response(&kp.public_key_pem, Some("Dev"), vec![], "1.3");
+        let result = verify_skill_offline(dir.path(), &discovery, None, None, None, Some("future"));
+        assert!(result.valid);
+        assert!(!result.expired);
+        assert!(result.expires_at.is_some());
+        assert!(
+            !result.warnings.iter().any(|w| w == "signature_expired"),
+            "no expiration warning expected"
+        );
+    }
+
+    #[test]
+    fn test_verify_with_past_ttl_passes_with_expired_warning() {
+        // Sign normally, then rewrite the .schemapin.sig with a past expires_at.
+        let dir = tempdir().unwrap();
+        make_skill_dir(dir.path(), &[("SKILL.md", b"---\nname: past\n---\n")]);
+        let kp = generate_key_pair().unwrap();
+        let mut sig =
+            sign_skill(dir.path(), &kp.private_key_pem, "example.com", None, None).unwrap();
+        sig.expires_at = Some(
+            (chrono::Utc::now() - chrono::Duration::days(1))
+                .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        );
+        sig.schemapin_version = "1.4".to_string();
+        let json = serde_json::to_string_pretty(&sig).unwrap();
+        fs::write(dir.path().join(".schemapin.sig"), format!("{}\n", json)).unwrap();
+
+        let discovery = build_well_known_response(&kp.public_key_pem, Some("Dev"), vec![], "1.3");
+        let result = verify_skill_offline(dir.path(), &discovery, None, None, None, Some("past"));
+        assert!(result.valid, "expired sigs are degraded, not failed");
+        assert!(result.expired);
+        assert!(result.warnings.iter().any(|w| w == "signature_expired"));
+    }
+
+    // ── v1.4: DNS TXT cross-verification tests ─────────────────────
+
+    #[test]
+    fn test_verify_with_dns_match_passes() {
+        let dir = tempdir().unwrap();
+        make_skill_dir(dir.path(), &[("SKILL.md", b"---\nname: dnsok\n---\n")]);
+        let kp = generate_key_pair().unwrap();
+        sign_skill(dir.path(), &kp.private_key_pem, "example.com", None, None).unwrap();
+
+        let discovery = build_well_known_response(&kp.public_key_pem, Some("Dev"), vec![], "1.4");
+        let fp = crypto::calculate_key_id(&kp.public_key_pem)
+            .unwrap()
+            .to_ascii_lowercase();
+        let txt = crate::dns::DnsTxtRecord {
+            version: "schemapin1".to_string(),
+            kid: None,
+            fingerprint: fp,
+        };
+        let result = verify_skill_offline_with_dns(
+            dir.path(),
+            &discovery,
+            None,
+            None,
+            None,
+            Some("dnsok"),
+            Some(&txt),
+        );
+        assert!(result.valid, "expected valid, got: {:?}", result);
+    }
+
+    #[test]
+    fn test_verify_with_dns_mismatch_fails() {
+        let dir = tempdir().unwrap();
+        make_skill_dir(dir.path(), &[("SKILL.md", b"---\nname: dnsbad\n---\n")]);
+        let kp = generate_key_pair().unwrap();
+        sign_skill(dir.path(), &kp.private_key_pem, "example.com", None, None).unwrap();
+
+        let discovery = build_well_known_response(&kp.public_key_pem, Some("Dev"), vec![], "1.4");
+        let txt = crate::dns::DnsTxtRecord {
+            version: "schemapin1".to_string(),
+            kid: None,
+            fingerprint: "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+                .to_string(),
+        };
+        let result = verify_skill_offline_with_dns(
+            dir.path(),
+            &discovery,
+            None,
+            None,
+            None,
+            Some("dnsbad"),
+            Some(&txt),
+        );
+        assert!(!result.valid);
+        assert_eq!(result.error_code, Some(ErrorCode::DomainMismatch));
+    }
+
+    #[test]
+    fn test_verify_without_dns_txt_unchanged() {
+        let dir = tempdir().unwrap();
+        make_skill_dir(dir.path(), &[("SKILL.md", b"---\nname: nodns\n---\n")]);
+        let kp = generate_key_pair().unwrap();
+        sign_skill(dir.path(), &kp.private_key_pem, "example.com", None, None).unwrap();
+
+        let discovery = build_well_known_response(&kp.public_key_pem, Some("Dev"), vec![], "1.4");
+        // dns_txt = None should behave exactly like verify_skill_offline.
+        let result = verify_skill_offline_with_dns(
+            dir.path(),
+            &discovery,
+            None,
+            None,
+            None,
+            Some("nodns"),
+            None,
+        );
+        assert!(result.valid);
+    }
+
+    #[test]
+    fn test_verify_with_unparseable_expires_at_warns() {
+        let dir = tempdir().unwrap();
+        make_skill_dir(dir.path(), &[("SKILL.md", b"---\nname: bad\n---\n")]);
+        let kp = generate_key_pair().unwrap();
+        let mut sig =
+            sign_skill(dir.path(), &kp.private_key_pem, "example.com", None, None).unwrap();
+        sig.expires_at = Some("not-a-timestamp".to_string());
+        let json = serde_json::to_string_pretty(&sig).unwrap();
+        fs::write(dir.path().join(".schemapin.sig"), format!("{}\n", json)).unwrap();
+
+        let discovery = build_well_known_response(&kp.public_key_pem, Some("Dev"), vec![], "1.3");
+        let result = verify_skill_offline(dir.path(), &discovery, None, None, None, Some("bad"));
+        assert!(result.valid);
+        assert!(!result.expired);
+        assert!(result
+            .warnings
+            .iter()
+            .any(|w| w == "signature_expires_at_unparseable"));
     }
 }

--- a/rust/src/verification.rs
+++ b/rust/src/verification.rs
@@ -27,6 +27,18 @@ pub struct VerificationResult {
     pub error_message: Option<String>,
     #[serde(default)]
     pub warnings: Vec<String>,
+    /// `true` when the signature carried an `expires_at` that has passed.
+    /// `valid` remains `true` (degraded, not failed) — callers should consult
+    /// this flag for confidence scoring or policy gating.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub expired: bool,
+    /// Mirrors the `expires_at` from the signature when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -50,6 +62,8 @@ impl VerificationResult {
             error_code: None,
             error_message: None,
             warnings: vec![],
+            expired: false,
+            expires_at: None,
         }
     }
 
@@ -62,7 +76,37 @@ impl VerificationResult {
             error_code: Some(code),
             error_message: Some(message.to_string()),
             warnings: vec![],
+            expired: false,
+            expires_at: None,
         }
+    }
+
+    /// Apply a signature `expires_at` check to a successful result.
+    ///
+    /// - If `expires_at` is `None`, the result is unchanged.
+    /// - If parseable and in the past, marks `expired = true`, copies
+    ///   `expires_at`, and pushes a `signature_expired` warning. `valid` is
+    ///   left intact (degraded, not failed).
+    /// - If parseable and in the future, just records `expires_at`.
+    /// - If unparseable, pushes a `signature_expires_at_unparseable` warning.
+    pub fn with_expiration_check(mut self, expires_at: Option<&str>) -> Self {
+        let Some(raw) = expires_at else {
+            return self;
+        };
+        match chrono::DateTime::parse_from_rfc3339(raw) {
+            Ok(ts) => {
+                self.expires_at = Some(raw.to_string());
+                if chrono::Utc::now() > ts.with_timezone(&chrono::Utc) {
+                    self.expired = true;
+                    self.warnings.push("signature_expired".to_string());
+                }
+            }
+            Err(_) => {
+                self.warnings
+                    .push("signature_expires_at_unparseable".to_string());
+            }
+        }
+        self
     }
 }
 


### PR DESCRIPTION
## Summary

First v1.4 alpha — Rust implementation of the two top-priority roadmap items:

1. **Signature expiration (\`expires_at\`)** — optional RFC 3339 field on \`.schemapin.sig\`. Verifiers degrade expired signatures (warn) instead of failing.
2. **DNS TXT cross-verification (\`_schemapin.{domain}\`)** — second-channel trust signal via DNS, independent of HTTPS hosting credentials.

Both are additive optional fields/records. v1.3 clients are unaffected.

This PR ships the **Rust** implementation and the spec updates. Python, JavaScript, and Go follow in subsequent alphas before v1.4.0.

## Spec changes (v1.4)

- New **Section 16** — Signature Expiration (\`expires_at\`, degraded vs. failed semantics, backward-compat).
- New **Section 17** — DNS TXT Cross-Verification (\`_schemapin.{domain}\` format, lookup name construction, hard-fail on mismatch).
- **Section 12** — version compatibility bumped to v1.4.

## API additions (Rust)

\`\`\`rust
// Signing with expiration
use schemapin::skill::{sign_skill_with_options, SignOptions};
let opts = SignOptions::new()
    .with_expires_in(chrono::Duration::days(180));
sign_skill_with_options(dir, &priv_pem, "example.com", opts)?;

// Verifying with optional DNS cross-check
use schemapin::dns::{parse_txt_record, fetch_dns_txt};
use schemapin::skill::verify_skill_offline_with_dns;
let txt = fetch_dns_txt("example.com").await?; // requires \`dns\` feature
let result = verify_skill_offline_with_dns(
    dir, &discovery, None, None, None, Some("tool"), txt.as_ref());
\`\`\`

\`VerificationResult\` gains:
- \`expired: bool\` — true when sig had \`expires_at\` and now > expires_at
- \`expires_at: Option<String>\` — mirrors the sig's expires_at when present
- Warning \`signature_expired\` (degraded, valid stays true)
- Warning \`signature_expires_at_unparseable\` (fail-open, doesn't invalidate)

## Cargo features

| Feature | Default | Brings in |
|---------|---------|-----------|
| \`fetch\` | off | \`reqwest\`, \`tokio\`, \`async-trait\` |
| \`dns\` (NEW) | off | \`hickory-resolver\`, \`tokio\`, \`async-trait\` |

## QA

| Check | Result |
|-------|--------|
| \`cargo build -j2\` | ok |
| \`cargo build -j2 --all-features\` | ok |
| \`cargo test -j2 --all-features\` | **109 passed** (was 88: +5 expiration, +13 DNS unit, +3 DNS integration) |
| \`cargo test -j2 --features dns --no-default-features\` | 109 passed |
| \`cargo test -j2 --features fetch --no-default-features\` | 109 passed |
| \`cargo clippy --all-features -j2 -- -D warnings\` | clean |
| \`cargo fmt --check\` | clean |

## Backward compatibility

- v1.3 verifiers ignore \`expires_at\` and any \`_schemapin\` TXT record. v1.3 signatures verify on v1.4 verifiers unchanged.
- v1.4 signatures **without** \`expires_at\` keep \`schemapin_version: "1.3"\`. Only sigs that opt into \`expires_in\` advertise \`"1.4"\`.

## Why draft

This is the Rust slice of v1.4. Holding for review on the Rust API shape (\`SignOptions\` builder, \`verify_skill_offline_with_dns\` variant) before fanning the same surface across Python / JS / Go to keep cross-language interop tight.

## Test plan

- [x] All cargo features build and test green
- [x] Clippy + fmt clean
- [ ] Cross-language interop tests (deferred — Python/JS/Go land in next alphas)
- [ ] DNS \`fetch_dns_txt\` integration test against a controlled TXT record (deferred — requires test fixture)

## Roadmap impact

- v1.4 priority #1 (expiration) and #3 (DNS TXT) — Rust complete
- Remaining v1.4 work: schema_version + previous_hash, canonicalization id, A2A context + AllowedDomains, scan-aware sigs, cross-agent schema cache (then Python/JS/Go fanout)