### PR TITLE
v1.4-alpha.1: signature expiration + DNS TXT cross-verification (JavaScript)

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -148,6 +148,56 @@ const workflow = new SchemaVerificationWorkflow();
 const result = await workflow.verifySchema(schema, signature, toolId, domain, autoPin);
 ```
 
+## v1.4-alpha (additive, optional)
+
+v1.4-alpha.1 adds two opt-in features. Both are additive — v1.3 verifiers
+ignore the new field and the new lookup, so signed skills remain
+backward-compatible.
+
+### Signature expiration (`expires_at`)
+
+Use `signSkillWithOptions` to write an `expires_at` timestamp:
+
+```javascript
+import { signSkillWithOptions } from 'schemapin/skill';
+
+signSkillWithOptions(skillDir, privateKeyPem, 'example.com', {
+    expiresIn: 30 * 24 * 60 * 60 * 1000  // 30 days, in milliseconds
+});
+```
+
+Verifiers past the expiration treat the result as **degraded, not failed**:
+`result.valid` stays `true`, `result.expired` is set to `true`, and
+`'signature_expired'` is appended to `result.warnings`.
+
+### DNS TXT cross-verification
+
+Publish a TXT record at `_schemapin.{domain}` of the form:
+
+```
+v=schemapin1; kid=acme-2026-01; fp=sha256:<lowercase-hex-of-public-key>
+```
+
+Then cross-check at verification time:
+
+```javascript
+import { fetchDnsTxt } from 'schemapin/dns';
+import { verifySkillOfflineWithDns } from 'schemapin/skill';
+
+const txt = await fetchDnsTxt('example.com');
+const result = verifySkillOfflineWithDns(
+    skillDir, discovery, null, null, null, 'tool-id', txt
+);
+```
+
+A mismatch produces `result.error_code === 'domain_mismatch'`. A missing
+record (`txt === null`) is a no-op. The DNS path uses Node's built-in
+`node:dns/promises` — no external dependency is added.
+
+Canonical guides:
+- https://docs.schemapin.org/signature-expiration/
+- https://docs.schemapin.org/dns-txt/
+
 ## Examples
 
 Run the included examples:

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "schemapin",
-  "version": "1.3.0",
+  "version": "1.4.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "schemapin",
-      "version": "1.3.0",
+      "version": "1.4.0-alpha.1",
       "cpu": [
         "x64",
         "arm64"
@@ -305,6 +305,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -554,6 +555,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schemapin",
-  "version": "1.3.0",
+  "version": "1.4.0-alpha.1",
   "description": "Cryptographic schema integrity verification for AI tools",
   "main": "src/index.js",
   "type": "module",
@@ -126,6 +126,9 @@
     },
     "./skill": {
       "import": "./src/skill.js"
+    },
+    "./dns": {
+      "import": "./src/dns.js"
     }
   },
   "publishConfig": {

--- a/javascript/src/dns.js
+++ b/javascript/src/dns.js
@@ -1,0 +1,168 @@
+/**
+ * DNS TXT cross-verification for SchemaPin v1.4.
+ *
+ * A tool provider MAY publish a TXT record at `_schemapin.{domain}` containing
+ * the public-key fingerprint advertised in `.well-known/schemapin.json`. When
+ * present, clients use it as a *second-channel* verification: the DNS
+ * credential chain is independent of the HTTPS hosting credential chain, so
+ * compromising one does not compromise the other.
+ *
+ * ## TXT record format
+ *
+ * ```
+ * _schemapin.example.com. IN TXT "v=schemapin1; kid=acme-2026-01; fp=sha256:a1b2c3..."
+ * ```
+ *
+ * Fields:
+ * - `v` - version tag (`schemapin1`); required
+ * - `fp` - key fingerprint (`sha256:<hex>`); required, lowercase hex
+ * - `kid` - optional key id, used for disambiguating multi-key endpoints
+ *
+ * ## Verification semantics
+ *
+ * - **Absent record** -> no effect (DNS TXT is optional)
+ * - **Present and matching** -> confidence boost
+ * - **Present and mismatching** -> hard failure with `DOMAIN_MISMATCH`
+ *
+ * Use {@link parseTxtRecord} to parse a raw TXT string and {@link verifyDnsMatch}
+ * to cross-check it against a discovery document. {@link fetchDnsTxt} performs
+ * the actual DNS lookup using Node's built-in `node:dns/promises`.
+ */
+
+import { resolveTxt } from 'node:dns/promises';
+import { KeyManager } from './crypto.js';
+
+/**
+ * Parsed `_schemapin.{domain}` TXT record.
+ *
+ * @typedef {Object} DnsTxtRecord
+ * @property {string} version
+ * @property {string|null} kid
+ * @property {string} fingerprint - Lowercase fingerprint string, including
+ *   the `sha256:` prefix.
+ */
+
+/**
+ * Parse a raw TXT record value
+ * (e.g. `"v=schemapin1; kid=acme-2026-01; fp=sha256:..."`).
+ *
+ * Whitespace around `;` and `=` is tolerated. Field order is not significant.
+ * Unknown fields are ignored (forward-compat). Throws on malformed input.
+ *
+ * @param {string} value - Raw TXT value
+ * @returns {DnsTxtRecord} Parsed record
+ * @throws {Error} If required fields are missing or version is unsupported
+ */
+export function parseTxtRecord(value) {
+    let version = null;
+    let kid = null;
+    let fingerprint = null;
+
+    for (const rawPart of value.split(';')) {
+        const part = rawPart.trim();
+        if (part.length === 0) {
+            continue;
+        }
+        const eqIdx = part.indexOf('=');
+        if (eqIdx === -1) {
+            throw new Error(`DNS TXT field missing '=': ${part}`);
+        }
+        const k = part.slice(0, eqIdx).trim().toLowerCase();
+        const v = part.slice(eqIdx + 1).trim();
+        if (k === 'v') {
+            version = v;
+        } else if (k === 'kid') {
+            kid = v;
+        } else if (k === 'fp') {
+            fingerprint = v.toLowerCase();
+        }
+        // Forward-compat: ignore unknown fields rather than reject.
+    }
+
+    if (version === null) {
+        throw new Error('DNS TXT record missing required \'v\' field');
+    }
+    if (version !== 'schemapin1') {
+        throw new Error(`DNS TXT unsupported version: ${version}`);
+    }
+    if (fingerprint === null) {
+        throw new Error('DNS TXT record missing required \'fp\' field');
+    }
+    if (!fingerprint.startsWith('sha256:')) {
+        throw new Error(`DNS TXT 'fp' must be sha256:<hex>: ${fingerprint}`);
+    }
+
+    return { version, kid, fingerprint };
+}
+
+/**
+ * Cross-check the DNS TXT record's fingerprint against the discovery document.
+ *
+ * Computes the SHA-256 fingerprint of `discovery.public_key_pem` and compares
+ * it (case-insensitively) against `txt.fingerprint`. Throws on mismatch.
+ *
+ * @param {Object} discovery - Well-known discovery document
+ * @param {DnsTxtRecord} txt - Parsed TXT record
+ * @throws {Error} If the fingerprints do not match
+ */
+export function verifyDnsMatch(discovery, txt) {
+    if (!discovery || !discovery.public_key_pem) {
+        throw new Error('DNS TXT verify: discovery missing public_key_pem');
+    }
+    const computed = KeyManager.calculateKeyFingerprint(discovery.public_key_pem).toLowerCase();
+    if (computed !== txt.fingerprint) {
+        throw new Error(
+            `DNS TXT fingerprint mismatch: discovery=${computed}, dns=${txt.fingerprint}`
+        );
+    }
+}
+
+/**
+ * Construct the DNS lookup name for a given tool domain.
+ *
+ * @param {string} domain - Tool domain (e.g. `example.com` or `example.com.`)
+ * @returns {string} DNS name (e.g. `_schemapin.example.com`)
+ */
+export function txtRecordName(domain) {
+    return `_schemapin.${domain.replace(/\.$/, '')}`;
+}
+
+/**
+ * Fetch and parse the `_schemapin.{domain}` TXT record.
+ *
+ * Returns:
+ * - `{ version, kid, fingerprint }` - record present and parseable
+ * - `null` - no `_schemapin` TXT record exists for the domain
+ *
+ * Throws on other resolution errors. Multiple matching TXT chunks are joined
+ * per RFC 1464 (concatenation in emit order). Multiple separate TXT records
+ * at the same name are not supported - the first valid `v=schemapin1` record
+ * wins.
+ *
+ * @param {string} domain - Tool domain
+ * @returns {Promise<DnsTxtRecord|null>}
+ */
+export async function fetchDnsTxt(domain) {
+    const name = txtRecordName(domain);
+    let records;
+    try {
+        records = await resolveTxt(name);
+    } catch (err) {
+        // `resolveTxt` throws an error with `code` = 'ENOTFOUND' / 'ENODATA'
+        // when no TXT record exists. Treat both as "absent".
+        if (err && (err.code === 'ENOTFOUND' || err.code === 'ENODATA')) {
+            return null;
+        }
+        throw new Error(`DNS TXT lookup failed for ${name}: ${err.message ?? err}`);
+    }
+
+    for (const chunks of records) {
+        // RFC 1464: a single TXT record may be split across multiple
+        // <character-strings>; node returns these as inner string arrays.
+        const joined = chunks.join('');
+        if (joined.includes('v=schemapin1')) {
+            return parseTxtRecord(joined);
+        }
+    }
+    return null;
+}

--- a/javascript/src/index.js
+++ b/javascript/src/index.js
@@ -49,7 +49,8 @@ export {
     ErrorCode,
     KeyPinStore,
     verifySchemaOffline,
-    verifySchemaWithResolver
+    verifySchemaWithResolver,
+    applyExpirationCheck
 } from './verification.js';
 
 // v1.3.0 new module
@@ -59,9 +60,19 @@ export {
     parseSkillName,
     loadSignature,
     signSkill,
+    signSkillWithOptions,
     verifySkillOffline,
+    verifySkillOfflineWithDns,
     verifySkillWithResolver,
     detectTamperedFiles
 } from './skill.js';
 
-export const version = '1.3.0';
+// v1.4.0-alpha.1: DNS TXT cross-verification
+export {
+    parseTxtRecord,
+    verifyDnsMatch,
+    txtRecordName,
+    fetchDnsTxt
+} from './dns.js';
+
+export const version = '1.4.0-alpha.1';

--- a/javascript/src/skill.js
+++ b/javascript/src/skill.js
@@ -1,9 +1,13 @@
 /**
- * Skill folder signing and verification for SchemaPin v1.3.
+ * Skill folder signing and verification for SchemaPin v1.3 / v1.4.
  *
  * Extends SchemaPin's ECDSA P-256 signing to cover file-based skill folders
  * (AgentSkills spec). Same keys, same .well-known discovery, new canonicalization
  * target.
+ *
+ * v1.4 additions (additive, optional, backward-compatible):
+ *   - `expires_at` field on `.schemapin.sig` via {@link signSkillWithOptions}.
+ *   - DNS TXT cross-verification via {@link verifySkillOfflineWithDns}.
  */
 
 import { createHash, createPrivateKey, createPublicKey } from 'node:crypto';
@@ -11,10 +15,24 @@ import { readFileSync, readdirSync, writeFileSync, lstatSync, existsSync } from 
 import { join, relative, basename, resolve } from 'node:path';
 import { KeyManager, SignatureManager } from './crypto.js';
 import { checkRevocationCombined } from './revocation.js';
-import { ErrorCode } from './verification.js';
+import { ErrorCode, applyExpirationCheck } from './verification.js';
+import { verifyDnsMatch } from './dns.js';
 
 export const SIGNATURE_FILENAME = '.schemapin.sig';
-const SCHEMAPIN_VERSION = '1.3';
+const SCHEMAPIN_VERSION_V13 = '1.3';
+const SCHEMAPIN_VERSION_V14 = '1.4';
+
+/**
+ * Format a Date as RFC 3339 UTC with seconds precision and `Z` suffix.
+ * Mirrors Rust's `chrono::SecondsFormat::Secs` rendering.
+ *
+ * @param {Date} date
+ * @returns {string} e.g. `2026-04-30T21:41:50Z`
+ */
+function toRfc3339Seconds(date) {
+    const iso = date.toISOString(); // 2026-04-30T21:41:50.123Z
+    return iso.replace(/\.\d{3}Z$/, 'Z');
+}
 
 /**
  * Recursively walk a directory in sorted order, collecting file entries.
@@ -159,6 +177,9 @@ export function loadSignature(skillDir) {
 /**
  * Canonicalize a skill directory, sign, and write .schemapin.sig.
  *
+ * v1.3 entry point. Preserved for backward compatibility — internally this is
+ * a thin wrapper over {@link signSkillWithOptions}.
+ *
  * @param {string} skillDir - Path to the skill folder
  * @param {string} privateKeyPem - PEM-encoded ECDSA P-256 private key
  * @param {string} domain - Signing domain (e.g. "thirdkey.ai")
@@ -167,6 +188,39 @@ export function loadSignature(skillDir) {
  * @returns {Object} The signature document that was written
  */
 export function signSkill(skillDir, privateKeyPem, domain, signerKid = null, skillName = null) {
+    return signSkillWithOptions(skillDir, privateKeyPem, domain, {
+        signerKid,
+        skillName
+    });
+}
+
+/**
+ * Canonicalize a skill directory, sign, and write .schemapin.sig with extended
+ * options (v1.4+).
+ *
+ * When `options.expiresIn` is set (milliseconds), an `expires_at` ISO 8601
+ * timestamp (RFC 3339 with `Z` suffix, second precision) is written and the
+ * `schemapin_version` field is bumped from `"1.3"` to `"1.4"`. Verifiers past
+ * that timestamp emit a `signature_expired` warning instead of failing — see
+ * {@link verifySkillOffline}.
+ *
+ * Options:
+ *   - `signerKid` - Override the signer key id (KID). Defaults to the
+ *     discovery fingerprint of the public key.
+ *   - `skillName` - Override the skill name. Defaults to the SKILL.md
+ *     frontmatter `name:` or directory basename.
+ *   - `expiresIn` - Time-to-live for the signature, in milliseconds. When set,
+ *     an `expires_at` field is written.
+ *
+ * @param {string} skillDir - Path to the skill folder
+ * @param {string} privateKeyPem - PEM-encoded ECDSA P-256 private key
+ * @param {string} domain - Signing domain
+ * @param {{ signerKid?: string|null, skillName?: string|null, expiresIn?: number|null }} [options]
+ * @returns {Object} The signature document that was written
+ */
+export function signSkillWithOptions(skillDir, privateKeyPem, domain, options = {}) {
+    const { signerKid: optSignerKid = null, skillName: optSkillName = null, expiresIn = null } = options;
+
     const skillPath = resolve(skillDir);
     const privateKey = KeyManager.loadPrivateKeyPem(privateKeyPem);
 
@@ -177,26 +231,53 @@ export function signSkill(skillDir, privateKeyPem, domain, signerKid = null, ski
 
     const { rootHash, manifest } = canonicalizeSkill(skillPath);
 
-    if (skillName === null || skillName === undefined) {
-        skillName = parseSkillName(skillPath);
-    }
+    const skillName = (optSkillName === null || optSkillName === undefined)
+        ? parseSkillName(skillPath)
+        : optSkillName;
 
-    if (signerKid === null || signerKid === undefined) {
-        signerKid = KeyManager.calculateKeyFingerprint(publicKeyPem);
-    }
+    const signerKid = (optSignerKid === null || optSignerKid === undefined)
+        ? KeyManager.calculateKeyFingerprint(publicKeyPem)
+        : optSignerKid;
 
     const signatureB64 = SignatureManager.signHash(rootHash, privateKey);
 
+    const now = new Date();
+    let expiresAt = null;
+    if (expiresIn !== null && expiresIn !== undefined) {
+        expiresAt = toRfc3339Seconds(new Date(now.getTime() + expiresIn));
+    }
+
+    const version = expiresAt !== null ? SCHEMAPIN_VERSION_V14 : SCHEMAPIN_VERSION_V13;
+
     const sigDoc = {
-        schemapin_version: SCHEMAPIN_VERSION,
+        schemapin_version: version,
         skill_name: skillName,
         skill_hash: `sha256:${rootHash.toString('hex')}`,
         signature: signatureB64,
-        signed_at: new Date().toISOString(),
+        signed_at: toRfc3339Seconds(now),
         domain: domain,
         signer_kid: signerKid,
         file_manifest: manifest
     };
+    if (expiresAt !== null) {
+        // Insert expires_at after signed_at to keep field order stable.
+        sigDoc.expires_at = expiresAt;
+        // Re-serialize in the documented field order.
+        const ordered = {
+            schemapin_version: sigDoc.schemapin_version,
+            skill_name: sigDoc.skill_name,
+            skill_hash: sigDoc.skill_hash,
+            signature: sigDoc.signature,
+            signed_at: sigDoc.signed_at,
+            expires_at: sigDoc.expires_at,
+            domain: sigDoc.domain,
+            signer_kid: sigDoc.signer_kid,
+            file_manifest: sigDoc.file_manifest
+        };
+        const sigPath = join(skillPath, SIGNATURE_FILENAME);
+        writeFileSync(sigPath, JSON.stringify(ordered, null, 2) + '\n', 'utf-8');
+        return ordered;
+    }
 
     const sigPath = join(skillPath, SIGNATURE_FILENAME);
     writeFileSync(sigPath, JSON.stringify(sigDoc, null, 2) + '\n', 'utf-8');
@@ -332,7 +413,52 @@ export function verifySkillOffline(skillDir, discovery, signatureData = null, re
         warnings: []
     };
 
+    // v1.4: apply signature expiration check (degraded, not failed).
+    if (signatureData.expires_at !== null && signatureData.expires_at !== undefined) {
+        applyExpirationCheck(resultObj, signatureData.expires_at);
+    }
+
     return resultObj;
+}
+
+/**
+ * Verify a signed skill folder offline with an optional DNS TXT cross-check (v1.4).
+ *
+ * Behaves identically to {@link verifySkillOffline}, then — when `dnsTxt` is
+ * non-null — verifies that the DNS TXT record's fingerprint matches the
+ * discovery key. A mismatch converts the result into a hard failure with
+ * `ErrorCode.DOMAIN_MISMATCH`. When `dnsTxt` is null, behaviour is unchanged
+ * (DNS TXT is an optional, additive trust signal).
+ *
+ * @param {string} skillDir - Path to skill directory
+ * @param {Object} discovery - Well-known discovery document
+ * @param {Object|null} signatureData - Pre-loaded signature data (loads from file if null)
+ * @param {Object|null} revocationDoc - Standalone revocation document
+ * @param {KeyPinStore|null} pinStore - TOFU pin store
+ * @param {string|null} toolId - Tool identifier for pinning
+ * @param {Object|null} dnsTxt - Parsed DNS TXT record (`{ version, kid, fingerprint }`)
+ * @returns {Object} Verification result
+ */
+export function verifySkillOfflineWithDns(skillDir, discovery, signatureData = null, revocationDoc = null, pinStore = null, toolId = null, dnsTxt = null) {
+    const result = verifySkillOffline(skillDir, discovery, signatureData, revocationDoc, pinStore, toolId);
+
+    if (!result.valid) {
+        return result;
+    }
+    if (dnsTxt === null || dnsTxt === undefined) {
+        return result;
+    }
+    try {
+        verifyDnsMatch(discovery, dnsTxt);
+        return result;
+    } catch (e) {
+        return {
+            valid: false,
+            domain: result.domain,
+            error_code: ErrorCode.DOMAIN_MISMATCH,
+            error_message: e.message
+        };
+    }
 }
 
 /**

--- a/javascript/src/verification.js
+++ b/javascript/src/verification.js
@@ -7,6 +7,45 @@ import { KeyManager, SignatureManager } from './crypto.js';
 import { checkRevocationCombined } from './revocation.js';
 
 /**
+ * Apply a signature `expires_at` check to a verification result (v1.4).
+ *
+ * Mirrors the Rust `VerificationResult::with_expiration_check` behaviour:
+ *
+ * - If `expiresAt` is null/undefined, the result is returned unchanged.
+ * - If parseable and in the past, sets `expired = true`, copies `expiresAt`,
+ *   and pushes a `'signature_expired'` warning. `valid` is left intact —
+ *   expired signatures are *degraded*, not failed.
+ * - If parseable and in the future, just records `expiresAt`.
+ * - If unparseable, pushes a `'signature_expires_at_unparseable'` warning
+ *   (fail-open) and does not mark expired.
+ *
+ * Mutates and returns the same `result` object for ergonomic chaining.
+ *
+ * @param {Object} result - VerificationResult-shaped object
+ * @param {string|null|undefined} expiresAt - ISO 8601 / RFC 3339 timestamp
+ * @returns {Object} The (possibly mutated) result
+ */
+export function applyExpirationCheck(result, expiresAt) {
+    if (expiresAt === null || expiresAt === undefined) {
+        return result;
+    }
+    if (!Array.isArray(result.warnings)) {
+        result.warnings = [];
+    }
+    const ts = new Date(expiresAt);
+    if (Number.isNaN(ts.getTime())) {
+        result.warnings.push('signature_expires_at_unparseable');
+        return result;
+    }
+    result.expires_at = expiresAt;
+    if (ts.getTime() < Date.now()) {
+        result.expired = true;
+        result.warnings.push('signature_expired');
+    }
+    return result;
+}
+
+/**
  * Structured error codes for verification results.
  */
 export const ErrorCode = Object.freeze({

--- a/javascript/tests/dns.test.js
+++ b/javascript/tests/dns.test.js
@@ -1,0 +1,142 @@
+/**
+ * Tests for DNS TXT cross-verification (v1.4).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { KeyManager } from '../src/crypto.js';
+import { parseTxtRecord, verifyDnsMatch, txtRecordName } from '../src/dns.js';
+
+// ---------------------------------------------------------------------------
+// parseTxtRecord
+// ---------------------------------------------------------------------------
+
+describe('parseTxtRecord', () => {
+    it('should parse a full record', () => {
+        const r = parseTxtRecord('v=schemapin1; kid=acme-2026-01; fp=sha256:abcd1234');
+        assert.equal(r.version, 'schemapin1');
+        assert.equal(r.kid, 'acme-2026-01');
+        assert.equal(r.fingerprint, 'sha256:abcd1234');
+    });
+
+    it('should parse a minimal record (no kid)', () => {
+        const r = parseTxtRecord('v=schemapin1;fp=sha256:abc');
+        assert.equal(r.version, 'schemapin1');
+        assert.equal(r.kid, null);
+        assert.equal(r.fingerprint, 'sha256:abc');
+    });
+
+    it('should lowercase the fingerprint', () => {
+        const r = parseTxtRecord('v=schemapin1; fp=SHA256:ABCDEF');
+        assert.equal(r.fingerprint, 'sha256:abcdef');
+    });
+
+    it('should tolerate whitespace and field order', () => {
+        const r = parseTxtRecord('  fp = sha256:beef ;  v = schemapin1  ');
+        assert.equal(r.version, 'schemapin1');
+        assert.equal(r.fingerprint, 'sha256:beef');
+    });
+
+    it('should ignore unknown fields (forward-compat)', () => {
+        const r = parseTxtRecord('v=schemapin1; fp=sha256:abc; future=ignoreme');
+        assert.equal(r.fingerprint, 'sha256:abc');
+        assert.equal(r.version, 'schemapin1');
+    });
+
+    it('should reject when v is missing', () => {
+        assert.throws(() => parseTxtRecord('fp=sha256:abc'), /missing required 'v'/);
+    });
+
+    it('should reject when fp is missing', () => {
+        assert.throws(() => parseTxtRecord('v=schemapin1'), /missing required 'fp'/);
+    });
+
+    it('should reject unsupported version', () => {
+        assert.throws(
+            () => parseTxtRecord('v=schemapin99; fp=sha256:abc'),
+            /unsupported version/
+        );
+    });
+
+    it('should reject fp without sha256: prefix', () => {
+        assert.throws(
+            () => parseTxtRecord('v=schemapin1; fp=abc'),
+            /must be sha256/
+        );
+    });
+
+    it('should reject a field that has no = sign', () => {
+        assert.throws(
+            () => parseTxtRecord('v=schemapin1; broken'),
+            /missing '='/
+        );
+    });
+
+    it('should tolerate a trailing semicolon', () => {
+        const r = parseTxtRecord('v=schemapin1; fp=sha256:abc;');
+        assert.equal(r.fingerprint, 'sha256:abc');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// txtRecordName
+// ---------------------------------------------------------------------------
+
+describe('txtRecordName', () => {
+    it('should prefix _schemapin', () => {
+        assert.equal(txtRecordName('example.com'), '_schemapin.example.com');
+    });
+
+    it('should strip a trailing dot from the domain', () => {
+        assert.equal(txtRecordName('example.com.'), '_schemapin.example.com');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// verifyDnsMatch
+// ---------------------------------------------------------------------------
+
+describe('verifyDnsMatch', () => {
+    function makeDiscovery(publicKeyPem) {
+        return {
+            schema_version: '1.4',
+            developer_name: 'Dev',
+            public_key_pem: publicKeyPem
+        };
+    }
+
+    it('should accept a matching fingerprint', () => {
+        const { publicKey } = KeyManager.generateKeypair();
+        const fp = KeyManager.calculateKeyFingerprint(publicKey).toLowerCase();
+        const txt = { version: 'schemapin1', kid: null, fingerprint: fp };
+        // Should not throw
+        verifyDnsMatch(makeDiscovery(publicKey), txt);
+    });
+
+    it('should accept a matching fingerprint case-insensitively', () => {
+        const { publicKey } = KeyManager.generateKeypair();
+        const fp = KeyManager.calculateKeyFingerprint(publicKey).toUpperCase();
+        // Mimic parser output: parser lowercases everything.
+        const txt = { version: 'schemapin1', kid: null, fingerprint: fp.toLowerCase() };
+        verifyDnsMatch(makeDiscovery(publicKey), txt);
+    });
+
+    it('should throw on fingerprint mismatch', () => {
+        const { publicKey } = KeyManager.generateKeypair();
+        const txt = {
+            version: 'schemapin1',
+            kid: null,
+            fingerprint: 'sha256:0000000000000000000000000000000000000000000000000000000000000000'
+        };
+        assert.throws(() => verifyDnsMatch(makeDiscovery(publicKey), txt), /mismatch/);
+    });
+
+    it('should throw when discovery is missing public_key_pem', () => {
+        const txt = {
+            version: 'schemapin1',
+            kid: null,
+            fingerprint: 'sha256:abc'
+        };
+        assert.throws(() => verifyDnsMatch({}, txt), /missing public_key_pem/);
+    });
+});

--- a/javascript/tests/skill.test.js
+++ b/javascript/tests/skill.test.js
@@ -12,7 +12,8 @@ import { buildRevocationDocument, addRevokedKey, RevocationReason } from '../src
 import { ErrorCode, KeyPinStore } from '../src/verification.js';
 import {
     SIGNATURE_FILENAME, canonicalizeSkill, parseSkillName, loadSignature,
-    signSkill, verifySkillOffline, detectTamperedFiles
+    signSkill, signSkillWithOptions, verifySkillOffline, verifySkillOfflineWithDns,
+    detectTamperedFiles
 } from '../src/skill.js';
 
 // ---------------------------------------------------------------------------
@@ -559,6 +560,196 @@ describe('Load Signature', () => {
                 () => loadSignature(join(dir, 'nosig')),
                 /not found/
             );
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// v1.4: Signature Expiration
+// ---------------------------------------------------------------------------
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('Signature Expiration (v1.4)', () => {
+    it('should write expires_at when expiresIn is set', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'skill-test-'));
+        try {
+            const { privateKey } = makeKeypair();
+            const skillDir = join(dir, 'skill');
+            createSkillDir(skillDir, { 'SKILL.md': '---\nname: ttl\n---\n# hi' });
+            const sig = signSkillWithOptions(skillDir, privateKey, 'example.com', {
+                expiresIn: 30 * ONE_DAY_MS
+            });
+            assert.equal(sig.schemapin_version, '1.4');
+            assert.ok(typeof sig.expires_at === 'string', 'expires_at should be a string');
+            assert.match(sig.expires_at, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+
+            // Round-trip through disk to ensure the JSON contains expires_at.
+            const onDisk = loadSignature(skillDir);
+            assert.equal(onDisk.expires_at, sig.expires_at);
+            assert.equal(onDisk.schemapin_version, '1.4');
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('should omit expires_at when expiresIn is not set', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'skill-test-'));
+        try {
+            const { privateKey } = makeKeypair();
+            const skillDir = join(dir, 'skill');
+            createSkillDir(skillDir, { 'SKILL.md': '---\nname: no-ttl\n---\n# hi' });
+            const sig = signSkill(skillDir, privateKey, 'example.com');
+            assert.equal(sig.schemapin_version, '1.3');
+            assert.equal(sig.expires_at, undefined);
+
+            const raw = readFileSync(join(skillDir, SIGNATURE_FILENAME), 'utf-8');
+            assert.ok(!raw.includes('expires_at'), 'JSON should omit expires_at');
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('should verify with future TTL: valid, not expired, no warning', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'skill-test-'));
+        try {
+            const { privateKey, publicKey } = makeKeypair();
+            const skillDir = join(dir, 'skill');
+            createSkillDir(skillDir, { 'SKILL.md': '---\nname: future\n---\n# hi' });
+            signSkillWithOptions(skillDir, privateKey, 'example.com', {
+                expiresIn: 30 * ONE_DAY_MS
+            });
+            const result = verifySkillOffline(skillDir, makeDiscovery(publicKey));
+            assert.equal(result.valid, true);
+            assert.notEqual(result.expired, true);
+            assert.ok(typeof result.expires_at === 'string');
+            assert.ok(
+                !result.warnings.includes('signature_expired'),
+                'no expiration warning expected for future TTL'
+            );
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('should verify with past TTL: valid (degraded), expired=true, warning', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'skill-test-'));
+        try {
+            const { privateKey, publicKey } = makeKeypair();
+            const skillDir = join(dir, 'skill');
+            createSkillDir(skillDir, { 'SKILL.md': '---\nname: past\n---\n# hi' });
+
+            // Sign normally, then rewrite the .schemapin.sig with a past expires_at.
+            const sig = signSkill(skillDir, privateKey, 'example.com');
+            const past = new Date(Date.now() - ONE_DAY_MS);
+            const expiredSig = {
+                ...sig,
+                schemapin_version: '1.4',
+                expires_at: past.toISOString().replace(/\.\d{3}Z$/, 'Z')
+            };
+            writeFileSync(
+                join(skillDir, SIGNATURE_FILENAME),
+                JSON.stringify(expiredSig, null, 2) + '\n',
+                'utf-8'
+            );
+
+            const result = verifySkillOffline(skillDir, makeDiscovery(publicKey));
+            assert.equal(result.valid, true, 'expired sigs are degraded, not failed');
+            assert.equal(result.expired, true);
+            assert.ok(result.warnings.includes('signature_expired'));
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('should warn (not fail) when expires_at is unparseable', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'skill-test-'));
+        try {
+            const { privateKey, publicKey } = makeKeypair();
+            const skillDir = join(dir, 'skill');
+            createSkillDir(skillDir, { 'SKILL.md': '---\nname: bad\n---\n# hi' });
+
+            const sig = signSkill(skillDir, privateKey, 'example.com');
+            const badSig = { ...sig, expires_at: 'not-a-timestamp' };
+            writeFileSync(
+                join(skillDir, SIGNATURE_FILENAME),
+                JSON.stringify(badSig, null, 2) + '\n',
+                'utf-8'
+            );
+
+            const result = verifySkillOffline(skillDir, makeDiscovery(publicKey));
+            assert.equal(result.valid, true);
+            assert.notEqual(result.expired, true);
+            assert.ok(result.warnings.includes('signature_expires_at_unparseable'));
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// v1.4: verifySkillOfflineWithDns integration
+// ---------------------------------------------------------------------------
+
+describe('verifySkillOfflineWithDns (v1.4)', () => {
+    it('should pass when DNS TXT fingerprint matches discovery', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'skill-test-'));
+        try {
+            const { privateKey, publicKey } = makeKeypair();
+            const skillDir = join(dir, 'skill');
+            createSkillDir(skillDir, { 'SKILL.md': '---\nname: dnsok\n---\n# hi' });
+            signSkill(skillDir, privateKey, 'example.com');
+
+            const fp = KeyManager.calculateKeyFingerprint(publicKey).toLowerCase();
+            const txt = { version: 'schemapin1', kid: null, fingerprint: fp };
+
+            const result = verifySkillOfflineWithDns(
+                skillDir, makeDiscovery(publicKey), null, null, null, 'dnsok', txt
+            );
+            assert.equal(result.valid, true);
+            assert.equal(result.domain, 'example.com');
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('should fail with DOMAIN_MISMATCH when DNS TXT fingerprint does not match', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'skill-test-'));
+        try {
+            const { privateKey, publicKey } = makeKeypair();
+            const skillDir = join(dir, 'skill');
+            createSkillDir(skillDir, { 'SKILL.md': '---\nname: dnsbad\n---\n# hi' });
+            signSkill(skillDir, privateKey, 'example.com');
+
+            const txt = {
+                version: 'schemapin1',
+                kid: null,
+                fingerprint: 'sha256:0000000000000000000000000000000000000000000000000000000000000000'
+            };
+            const result = verifySkillOfflineWithDns(
+                skillDir, makeDiscovery(publicKey), null, null, null, 'dnsbad', txt
+            );
+            assert.equal(result.valid, false);
+            assert.equal(result.error_code, ErrorCode.DOMAIN_MISMATCH);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('should be a no-op when dnsTxt is null', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'skill-test-'));
+        try {
+            const { privateKey, publicKey } = makeKeypair();
+            const skillDir = join(dir, 'skill');
+            createSkillDir(skillDir, { 'SKILL.md': '---\nname: nodns\n---\n# hi' });
+            signSkill(skillDir, privateKey, 'example.com');
+
+            const result = verifySkillOfflineWithDns(
+                skillDir, makeDiscovery(publicKey), null, null, null, 'nodns', null
+            );
+            assert.equal(result.valid, true);
         } finally {
             rmSync(dir, { recursive: true, force: true });
         }


### PR DESCRIPTION
## Summary

JavaScript port of the two top-priority v1.4 roadmap items, mirroring the
Rust implementation on `feature/v1.4-expires-dns` (PR #28). Both features
are additive optional fields/records — v1.3 clients are unaffected.

- **Signature expiration** — optional `expires_at` (RFC 3339 UTC, second
  precision, `Z` suffix) on `.schemapin.sig`. Verifiers past the
  expiration mark the result as `expired` and emit a `signature_expired`
  warning, but `valid` stays `true` (degraded, not failed).
- **DNS TXT cross-verification** — optional `_schemapin.{domain}` TXT
  record of the form `v=schemapin1; kid=...; fp=sha256:<hex>`,
  cross-checked against the discovery key. Mismatch is a hard
  `DOMAIN_MISMATCH`; absent record is a no-op.

## API additions

| API | Module | Purpose |
| --- | --- | --- |
| `signSkillWithOptions(skillDir, pem, domain, { signerKid?, skillName?, expiresIn? })` | `skill.js` | Sign with extended options; `expiresIn` is in milliseconds |
| `signSkill(..)` | `skill.js` | Now a thin wrapper over `signSkillWithOptions` (signature unchanged) |
| `verifySkillOfflineWithDns(skillDir, discovery, sig, rev, pinStore, toolId, dnsTxt)` | `skill.js` | Wraps `verifySkillOffline` with optional DNS TXT cross-check |
| `applyExpirationCheck(result, expiresAt)` | `verification.js` | Mirrors Rust's `with_expiration_check`; chainable |
| `parseTxtRecord(value)` | `dns.js` (new) | Parse `v=schemapin1; kid=...; fp=sha256:<hex>` |
| `verifyDnsMatch(discovery, txt)` | `dns.js` (new) | Cross-check DNS TXT fingerprint against discovery PEM |
| `txtRecordName(domain)` | `dns.js` (new) | Build `_schemapin.{domain}` (strips trailing dot) |
| `fetchDnsTxt(domain)` | `dns.js` (new) | Async lookup; returns `null` for absent record |

The `VerificationResult`-shaped return object gains two new optional
fields: `expired: boolean` (omitted unless `true`) and
`expires_at: string | null`. New warning strings: `'signature_expired'`
and `'signature_expires_at_unparseable'`.

## Dependencies

**No new external dependencies.** DNS lookups use Node's built-in
`node:dns/promises` (`resolveTxt`). The JS implementation remains
zero-runtime-dependency.

## Test results

- Before: **128 tests pass** (32 suites)
- After: **153 tests pass** (32 suites) — +25 new tests
  - `tests/skill.test.js`: +5 expiration tests, +3 `verifySkillOfflineWithDns` integration tests
  - `tests/dns.test.js` (new): 17 unit tests covering full/minimal record parse, fingerprint case-folding, whitespace tolerance, field-order independence, unknown-field forward-compat, all rejection paths, `txtRecordName` trailing-dot handling, and `verifyDnsMatch` match/mismatch
- ESLint: **0 errors** (37 pre-existing warnings, untouched)

## Backward compatibility

Fully backward-compatible. v1.3 callers see no behavior change beyond the
`signed_at` field switching from millisecond precision to second precision
to match the Rust output (informational field, no consumers depend on the
sub-second portion). The legacy `signSkill(skillDir, pem, domain, kid?, name?)`
signature is preserved exactly. Verifiers ignore `expires_at` if the
signature lacks it; `verifySkillOfflineWithDns(.., null)` is identical to
`verifySkillOffline(..)`.

Depends on #28 for spec/docs.

## Test plan

- [x] `cd javascript && npm install && npm test` — all 153 tests pass
- [x] `npm run lint` — 0 errors
- [x] Verify cross-language interop with Rust (TXT parser produces same
      `{ version, kid, fingerprint }` shape; expiration semantics
      match `with_expiration_check`)