### PR TITLE
v1.4-alpha.2: schema version binding (all 4 languages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to the SchemaPin project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0-alpha.2] - 2026-05-01
+
+### Added
+
+#### Schema Version Binding (`schema_version` + `previous_hash`) — All Four Languages
+
+- **`SkillSignature.schema_version`**: Optional caller-supplied semver string identifying *this* version of the signed artifact. Opaque to SchemaPin (treated as a tag); surfaced via `VerificationResult.schema_version` for policy use.
+- **`SkillSignature.previous_hash`**: Optional `sha256:<hex>` of the prior signed version's `skill_hash`. Forms a hash chain across successive signatures.
+- **`SignOptions.with_schema_version` / `SignOptions.with_previous_hash`** (Rust); equivalent fields on the Python dataclass, JS options object, and Go struct. Either field bumps `schemapin_version` to `"1.4"`.
+- **`verify_chain(current, previous)`**: New chain-verification helper in every language. Returns success when `current.previous_hash == previous.skill_hash`. Distinguishes two failure modes — `NoPreviousHash` (current sig lacks the field) and `Mismatch` (both present but unequal). Pure-metadata check; cryptographic verification of both signatures must happen separately.
+- **`VerificationResult.schema_version` / `VerificationResult.previous_hash`**: New optional fields, mirrored from the signature when present. No automatic enforcement — chain verification is opt-in via `verify_chain`.
+- **`ChainError`**: Per-language error/exception type carrying the kind (`no_previous_hash` / `mismatch`) and, on mismatch, the expected and observed values.
+
+#### Specification Updates (v1.4)
+
+- **Section 18**: Schema Version Binding — wire format, informational verifier semantics for `schema_version` and `previous_hash`, opt-in chain verification, operational pattern (per-tool `latest_known_hash` pinned alongside the TOFU key), backward compatibility.
+
+### Changed
+
+- All four implementations bumped to `1.4.0-alpha.2` (`1.4.0a2` for Python per PEP 440).
+
+### Notes
+
+- Item #2 from the v1.4 roadmap. The full v1.4.0 release also requires items 4–8 (canonicalization id, A2A context, A2A trust bundles, scan-aware signatures, cross-agent schema cache).
+- Both new fields are additive optional fields — v1.3 verifiers ignore them, and v1.4 signatures without lineage opts behave identically to v1.3 signatures.
+
 ## [1.4.0-alpha.1] - 2026-04-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ SchemaPin lets tool developers sign their schemas and skill folders with ECDSA P
 - **Skill folder signing** for AgentSkills (SKILL.md + file manifests)
 - **Cross-language** — Python, JavaScript, Go, and Rust implementations
 
-> **v1.4.0-alpha.1** (Rust only — preview): optional [signature expiration (`expires_at`)](https://docs.schemapin.org/signature-expiration/) with degraded-not-failed verification, and optional [DNS TXT cross-verification](https://docs.schemapin.org/dns-txt/) at `_schemapin.{domain}` for second-channel trust. Both are additive optional fields/records — v1.3 verifiers ignore them, v1.4 verifiers handle both. Python, JavaScript, and Go ports follow in subsequent alphas before the v1.4.0 release.
+> **v1.4.0-alpha.2** (all four languages): three additive optional features — [signature expiration (`expires_at`)](https://docs.schemapin.org/signature-expiration/) with degraded-not-failed verification, [DNS TXT cross-verification](https://docs.schemapin.org/dns-txt/) at `_schemapin.{domain}` for second-channel trust, and [schema version binding (`schema_version` + `previous_hash`)](https://docs.schemapin.org/schema-version-binding/) for opt-in lineage chain enforcement that defends against rug-pull substitutions. v1.3 verifiers ignore the new fields; v1.4 verifiers handle both. The remaining v1.4 items (canonicalization id, A2A context, A2A trust bundles, scan-aware sigs, cross-agent schema cache) ship in subsequent alphas before stable v1.4.0.
 
 ## Quick Start
 
@@ -62,9 +62,9 @@ go install github.com/ThirdKeyAi/schemapin/go/cmd/...@latest
 ```toml
 [dependencies]
 schemapin = "1.3.0"
-# v1.4.0-alpha.1 is also published — opt in for signature expiration
-# and DNS TXT cross-verification:
-# schemapin = { version = "1.4.0-alpha.1", features = ["dns"] }
+# v1.4.0-alpha.2 is also published — opt in for signature expiration,
+# DNS TXT cross-verification, and schema version binding:
+# schemapin = { version = "1.4.0-alpha.2", features = ["dns"] }
 ```
 
 ## Documentation
@@ -76,8 +76,9 @@ schemapin = "1.3.0"
 | Skill Signing | [docs.schemapin.org/skill-signing](https://docs.schemapin.org/skill-signing/) |
 | Trust Bundles | [docs.schemapin.org/trust-bundles](https://docs.schemapin.org/trust-bundles/) |
 | Revocation | [docs.schemapin.org/revocation](https://docs.schemapin.org/revocation/) |
-| Signature Expiration *(v1.4-alpha, Rust)* | [docs.schemapin.org/signature-expiration](https://docs.schemapin.org/signature-expiration/) |
-| DNS TXT Cross-Verification *(v1.4-alpha, Rust)* | [docs.schemapin.org/dns-txt](https://docs.schemapin.org/dns-txt/) |
+| Signature Expiration *(v1.4-alpha, all 4 langs)* | [docs.schemapin.org/signature-expiration](https://docs.schemapin.org/signature-expiration/) |
+| DNS TXT Cross-Verification *(v1.4-alpha, all 4 langs)* | [docs.schemapin.org/dns-txt](https://docs.schemapin.org/dns-txt/) |
+| Schema Version Binding *(v1.4-alpha, all 4 langs)* | [docs.schemapin.org/schema-version-binding](https://docs.schemapin.org/schema-version-binding/) |
 | Deployment | [docs.schemapin.org/deployment](https://docs.schemapin.org/deployment/) |
 | Troubleshooting | [docs.schemapin.org/troubleshooting](https://docs.schemapin.org/troubleshooting/) |
 | Technical Specification | [TECHNICAL_SPECIFICATION.md](TECHNICAL_SPECIFICATION.md) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,7 +16,8 @@
 | **1.1.0** | 2026-01 | Revocation documents, standalone revocation endpoint | Shipped |
 | **1.2.0** | 2026-02 | Offline verification, trust bundles, resolver abstraction | Shipped |
 | **1.3.0** | 2026-02 | AgentSkills security — skill folder signing | **Shipped** |
-| **1.4.0-alpha.1** | 2026-04-30 | Signature expiration + DNS TXT cross-verification (Rust) | **Shipped** |
+| **1.4.0-alpha.1** | 2026-04-30 | Signature expiration + DNS TXT cross-verification (all 4 langs) | **Shipped** |
+| **1.4.0-alpha.2** | 2026-05-01 | Schema version binding (`schema_version` + `previous_hash` lineage chain, all 4 langs) | **Shipped** |
 | **1.4.0** | Q2-Q3 2026 | Signature lifecycle, version binding, A2A trust | In progress |
 | **1.5.0** | Q4 2026 | Multi-key endorsement, permissions, advanced revocation | Planning |
 
@@ -116,7 +117,7 @@ Right now, a signature is valid forever once created. There's a `signed_at` time
 }
 ```
 
-### Schema Version Binding
+### Schema Version Binding — **Shipped (alpha.2, all 4 langs)**
 
 SchemaPin signs a schema at a point in time, but there's no concept of "this is version 3.2 of this tool's schema, superseding version 3.1." If a developer legitimately updates their tool, clients with the old schema pinned have no way to know whether the new schema is an authorized upgrade or a rug pull.
 
@@ -323,4 +324,4 @@ We welcome input on roadmap priorities:
 
 ---
 
-*Last updated: 2026-04-30 (v1.4.0-alpha.1 — Rust signature expiration + DNS TXT cross-verification)*
+*Last updated: 2026-05-01 (v1.4.0-alpha.2 — schema version binding across all four language implementations)*

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: schemapin
 title: SchemaPin
-description: Cryptographic tool schema verification to prevent MCP Rug Pull attacks — ECDSA P-256 signing, SHA-256 hashing, TOFU key pinning, .well-known discovery, signed revocation documents, and (v1.4-alpha, Rust) signature expiration plus DNS TXT cross-verification
-version: 1.4.0-alpha.1
+description: Cryptographic tool schema verification to prevent MCP Rug Pull attacks — ECDSA P-256 signing, SHA-256 hashing, TOFU key pinning, .well-known discovery, signed revocation documents, and (v1.4-alpha across all four languages) signature expiration, DNS TXT cross-verification, and schema version binding (lineage chain)
+version: 1.4.0-alpha.2
 stable_version: 1.3.0
 ---
 
@@ -299,7 +299,59 @@ tampered = detect_tampered_files(current_manifest, sig.file_manifest)
 
 ---
 
-## v1.4.0-alpha.1 Features (Rust only — preview)
+## v1.4.0-alpha.2 Features (all four languages — preview)
+
+### Schema Version Binding (`schema_version` + `previous_hash`)
+
+Two additive optional fields on `.schemapin.sig` give publishers a way to declare lineage and verifiers a way to enforce it. Defends against rug-pull substitutions where an attacker swaps a tampered schema under the same name.
+
+**Rust:**
+```rust
+use schemapin::skill::{sign_skill_with_options, SignOptions, verify_chain};
+
+let v1 = sign_skill_with_options(&dir_v1, &priv_pem, "example.com",
+    SignOptions::new().with_schema_version("1.0.0"))?;
+
+let v2 = sign_skill_with_options(&dir_v2, &priv_pem, "example.com",
+    SignOptions::new()
+        .with_schema_version("1.1.0")
+        .with_previous_hash(&v1.skill_hash))?;
+
+verify_chain(&v2, &v1)?;  // Pure metadata check; both must already be cryptographically verified.
+```
+
+**Python:**
+```python
+from schemapin.skill import SkillSigner, SignOptions, verify_chain
+v2 = SkillSigner.sign_with_options(dir_v2, priv_pem, "example.com",
+    SignOptions(schema_version="1.1.0", previous_hash=v1["skill_hash"]))
+verify_chain(v2, v1)
+```
+
+**JavaScript:**
+```javascript
+import { signSkillWithOptions, verifyChain } from 'schemapin';
+const v2 = signSkillWithOptions(dirV2, privPem, 'example.com',
+    { schemaVersion: '1.1.0', previousHash: v1.skill_hash });
+verifyChain(v2, v1);
+```
+
+**Go:**
+```go
+v2, _ := skill.SignSkillWithOptions(dirV2, privPEM, "example.com", skill.SignOptions{
+    SchemaVersion: "1.1.0",
+    PreviousHash:  v1.SkillHash,
+})
+err := skill.VerifyChain(v2, v1)
+```
+
+`VerificationResult` gains `schema_version` and `previous_hash` fields — verifiers surface these informationally. Chain enforcement is opt-in via `verify_chain` (or the language equivalent). `ChainError` distinguishes two failure modes: `no_previous_hash` (current sig lacks the field) and `mismatch` (both present but unequal — likely substitution).
+
+Full guide: **[docs/schema-version-binding.md](docs/schema-version-binding.md)**.
+
+---
+
+## v1.4.0-alpha.1 Features (all four languages — preview)
 
 Both features are **additive optional fields/records**: v1.3 verifiers ignore them, and v1.4 signatures without these fields behave identically to v1.3. Python, JavaScript, and Go ports follow in subsequent alphas before the v1.4.0 release.
 

--- a/TECHNICAL_SPECIFICATION.md
+++ b/TECHNICAL_SPECIFICATION.md
@@ -405,3 +405,83 @@ Implementations MUST strip a single trailing dot from the input domain before co
 input "example.com"  → "_schemapin.example.com"
 input "example.com." → "_schemapin.example.com"
 ```
+
+### **18. Schema Version Binding (v1.4)**
+
+SchemaPin v1.4 adds two OPTIONAL fields to signature documents that, together, defend against rug-pull attacks where an attacker substitutes a tampered schema or skill out-of-band under the same name as a previously trusted version.
+
+#### **18.1. Format**
+
+Two new optional fields on `.schemapin.sig` (and on schema signatures by extension):
+
+```json
+{
+  "schemapin_version": "1.4",
+  "skill_name": "example-skill",
+  "skill_hash": "sha256:b7e8...",
+  "signature": "MEUCIQ...",
+  "signed_at": "2026-04-30T12:00:00Z",
+  "schema_version": "2.1.0",
+  "previous_hash": "sha256:a1b2c3...",
+  "domain": "thirdkey.ai",
+  "signer_kid": "thirdkey-2026-04",
+  "file_manifest": { /* ... */ }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `schema_version` | string | Caller-supplied semver string identifying *this* version of the signed artifact. The value is opaque to SchemaPin (treat as a tag). |
+| `previous_hash` | string | `sha256:<hex>` of the *prior* signed version's `skill_hash`. Forms a hash chain across successive signatures. |
+
+Either field, when present, bumps `schemapin_version` to `"1.4"`. Documents without either field MAY remain `"1.3"`.
+
+#### **18.2. Verifier Semantics — Informational**
+
+`schema_version` and `previous_hash` are surfaced on `VerificationResult` (mirroring the same field names) but are **not** automatically enforced. Verifiers MUST:
+
+- Copy `schema_version` from the signature onto the result when present.
+- Copy `previous_hash` from the signature onto the result when present.
+
+Verifiers MUST NOT:
+
+- Reject a signature solely because `schema_version` is absent or unknown.
+- Reject a signature solely because `previous_hash` doesn't match a record the verifier holds (callers do this explicitly via the chain-verification helper below).
+
+#### **18.3. Chain Verification — Opt-In**
+
+Implementations MUST provide a chain-verification helper (named `verify_chain` or the language-equivalent) that takes a `current` signature and a `previous` signature and returns success when:
+
+```
+current.previous_hash == previous.skill_hash
+```
+
+The helper MUST distinguish two failure modes for callers:
+
+| Failure | Condition |
+|---------|-----------|
+| **No previous hash** | `current.previous_hash` is absent / empty. |
+| **Mismatch** | Both fields present but unequal. The error MUST include both the expected and observed values. |
+
+This is a pure-metadata check — no cryptography is re-evaluated. Both signatures MUST already be cryptographically verified independently for the chain check to be meaningful. Skipping the underlying signature verification would let an attacker forge a "chained" successor to any signature they choose.
+
+#### **18.4. Operational Use**
+
+A publisher MAINTAINING a chain SHOULD:
+
+1. After signing v_n, record the resulting `skill_hash`.
+2. When signing v_{n+1}, set `previous_hash = skill_hash_of_v_n`.
+3. Distribute v_{n+1} alongside (or with the ability for verifiers to fetch) v_n.
+
+A verifier APPLYING chain enforcement SHOULD maintain a per-tool `latest_known_hash` pinned alongside the TOFU public key. On encountering a signature with `previous_hash`:
+
+- Match against `latest_known_hash` → accept and roll forward.
+- No match → prompt the operator (similar to TOFU key rotation) before accepting; an unauthorized substitution would either omit `previous_hash` or claim a hash the verifier has not seen.
+
+This pairs cleanly with `schema_version`: the verifier can also enforce monotonic version progression as a policy (e.g., refuse downgrades).
+
+#### **18.5. Backward Compatibility**
+
+- v1.3 verifiers ignore both fields; signatures continue to verify.
+- v1.4 signatures without `schema_version` or `previous_hash` behave identically to v1.3 signatures.
+- The chain-verification helper is opt-in: callers who don't track lineage are unaffected.

--- a/context7.json
+++ b/context7.json
@@ -3,7 +3,7 @@
   "url": "https://context7.com/thirdkeyai/schemapin",
   "public_key": "pk_Ehy7QXQTu2Keb0e5BNeyx",
   "projectTitle": "SchemaPin",
-  "description": "Cryptographic tool schema verification to prevent MCP Rug Pull attacks — ECDSA P-256 signing, SHA-256 hashing, TOFU key pinning, .well-known discovery, signed key revocation documents, and (v1.4-alpha, Rust) optional signature expiration plus DNS TXT cross-verification. Stable implementations in Python, JavaScript, Rust, and Go. Part of the ThirdKey trust stack: SchemaPin (tool integrity) → AgentPin (agent identity) → Symbiont (runtime).",
+  "description": "Cryptographic tool schema verification to prevent MCP Rug Pull attacks — ECDSA P-256 signing, SHA-256 hashing, TOFU key pinning, .well-known discovery, signed key revocation documents, and (v1.4-alpha across all four languages) optional signature expiration, DNS TXT cross-verification, and schema version binding (`schema_version` + `previous_hash` lineage chain). Stable implementations in Python, JavaScript, Rust, and Go. Part of the ThirdKey trust stack: SchemaPin (tool integrity) → AgentPin (agent identity) → Symbiont (runtime).",
   "folders": [
     "SKILL.md",
     "README.md",
@@ -20,6 +20,7 @@
     "docs/revocation.md",
     "docs/signature-expiration.md",
     "docs/dns-txt.md",
+    "docs/schema-version-binding.md",
     "docs/deployment.md",
     "docs/troubleshooting.md"
   ],
@@ -75,6 +76,7 @@
     "Key fingerprints are SHA-256 of the DER-encoded SubjectPublicKeyInfo, formatted as `sha256:<lowercase-hex>`. The `sha256:` prefix is required.",
     "Never hardcode or embed private keys — use KeyManager to generate and PEM files for storage",
     "SchemaPin protects MCP tool schemas from tampering — sign on publish, verify on load",
-    "v1.4.0-alpha.1 (Rust only — preview): optional `expires_at` field on .schemapin.sig (degraded-not-failed semantics — `valid` stays true, `expired` becomes true, `signature_expired` warning appended), and optional `_schemapin.{domain}` DNS TXT record (`v=schemapin1; kid=...; fp=sha256:...`) for second-channel cross-verification (mismatch is hard DOMAIN_MISMATCH; absent is no-op). Both are additive optional fields/records — v1.3 verifiers ignore them. Python, JavaScript, and Go ports follow in subsequent alphas."
+    "v1.4.0-alpha.1 (all four languages): optional `expires_at` field on .schemapin.sig (degraded-not-failed semantics — `valid` stays true, `expired` becomes true, `signature_expired` warning appended), and optional `_schemapin.{domain}` DNS TXT record (`v=schemapin1; kid=...; fp=sha256:...`) for second-channel cross-verification (mismatch is hard DOMAIN_MISMATCH; absent is no-op). Both are additive optional fields/records — v1.3 verifiers ignore them.",
+    "v1.4.0-alpha.2 (all four languages): optional `schema_version` (caller-supplied semver string identifying *this* version, surfaced informationally) and `previous_hash` (`sha256:<hex>` of the prior signed version's `skill_hash`, forming a hash chain) on .schemapin.sig. Pair with the new `verify_chain(current, previous)` helper to opt into chain enforcement — defends against rug-pull substitutions where an attacker swaps a tampered schema/skill under the same name. ChainError distinguishes `no_previous_hash` from `mismatch`. Pure metadata; no extra crypto. v1.3 verifiers ignore both fields."
   ]
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,8 +77,9 @@ All four implementations use identical crypto (ECDSA P-256 + SHA-256) — cross-
 | [Skill Signing](skill-signing.md) | Sign and verify skill directories (v1.3) |
 | [Trust Bundles](trust-bundles.md) | Offline verification and pluggable resolvers |
 | [Revocation](revocation.md) | Rotate keys, publish revocation documents, fail closed |
-| [Signature Expiration](signature-expiration.md) | `expires_at` field for degraded-not-failed verification (v1.4-alpha, Rust) |
-| [DNS TXT Cross-Verification](dns-txt.md) | Second-channel `_schemapin.{domain}` lookups (v1.4-alpha, Rust) |
+| [Signature Expiration](signature-expiration.md) | `expires_at` field for degraded-not-failed verification (v1.4-alpha, all 4 languages) |
+| [DNS TXT Cross-Verification](dns-txt.md) | Second-channel `_schemapin.{domain}` lookups (v1.4-alpha, all 4 languages) |
+| [Schema Version Binding](schema-version-binding.md) | `schema_version` + `previous_hash` lineage chain to defend against rug-pull substitutions (v1.4-alpha, all 4 languages) |
 | [Deployment](deployment.md) | Serve `.well-known` endpoints in production |
 | [Troubleshooting](troubleshooting.md) | Common issues and solutions |
 

--- a/docs/schema-version-binding.md
+++ b/docs/schema-version-binding.md
@@ -1,0 +1,251 @@
+# Schema Version Binding (`schema_version` + `previous_hash`)
+
+> **Status:** v1.4.0-alpha.2 — implemented in **Rust, Python, JavaScript, and Go**. All four implementations produce byte-identical wire format.
+
+A v1.3 signature pins a key to a tool, but a developer publishing a *new version* of the same tool has no way to declare it as such. Clients with the prior schema pinned can't tell whether the new bytes are an authorized v2.1.0 succeeding the v2.0.0 they trust, or an unauthorized substitution under the same name. ECDSA signatures alone don't help — both versions are validly signed by the same key.
+
+SchemaPin v1.4 adds two OPTIONAL fields to `.schemapin.sig` (and to schema signatures) that, together, give publishers a way to declare lineage and verifiers a way to enforce it:
+
+- **`schema_version`** — caller-supplied semver string identifying *this* version of the artifact. Opaque to SchemaPin (treated as a tag).
+- **`previous_hash`** — `sha256:<hex>` of the prior signed version's `skill_hash`. Forms a hash chain across successive signatures.
+
+The fields are surfaced on `VerificationResult` for inspection but are **not automatically enforced** — callers opt into chain verification by calling `verify_chain` (or the language equivalent) with both the current and previous signature documents.
+
+---
+
+## Wire format
+
+```json
+{
+  "schemapin_version": "1.4",
+  "skill_name": "example-skill",
+  "skill_hash": "sha256:b7e8f9...",
+  "signature": "MEUCIQ...",
+  "signed_at": "2026-04-30T12:00:00Z",
+  "expires_at": "2026-10-30T12:00:00Z",
+  "schema_version": "2.1.0",
+  "previous_hash": "sha256:a1b2c3...",
+  "domain": "thirdkey.ai",
+  "signer_kid": "thirdkey-2026-04",
+  "file_manifest": { /* ... */ }
+}
+```
+
+Either field, when present, bumps `schemapin_version` to `"1.4"`. Documents without either field remain `"1.3"`. v1.3 verifiers ignore the new fields entirely.
+
+See [Technical specification §18](https://github.com/ThirdKeyAI/SchemaPin/blob/main/TECHNICAL_SPECIFICATION.md#18-schema-version-binding-v14) for the normative definition.
+
+---
+
+## Signing with lineage
+
+### Rust
+
+```rust
+use schemapin::skill::{sign_skill_with_options, SignOptions};
+
+// Initial release
+let v1 = sign_skill_with_options(
+    &dir_v1,
+    &priv_pem,
+    "example.com",
+    SignOptions::new().with_schema_version("1.0.0"),
+)?;
+// v1.skill_hash → "sha256:a1b2c3..."
+
+// Next release: chain to v1
+let v2 = sign_skill_with_options(
+    &dir_v2,
+    &priv_pem,
+    "example.com",
+    SignOptions::new()
+        .with_schema_version("1.1.0")
+        .with_previous_hash(&v1.skill_hash),
+)?;
+```
+
+### Python
+
+```python
+from schemapin.skill import SkillSigner, SignOptions
+
+v1 = SkillSigner.sign_with_options(
+    dir_v1, priv_pem, "example.com",
+    SignOptions(schema_version="1.0.0"),
+)
+
+v2 = SkillSigner.sign_with_options(
+    dir_v2, priv_pem, "example.com",
+    SignOptions(
+        schema_version="1.1.0",
+        previous_hash=v1["skill_hash"],
+    ),
+)
+```
+
+### JavaScript
+
+```javascript
+import { signSkillWithOptions } from 'schemapin';
+
+const v1 = signSkillWithOptions(dirV1, privPem, 'example.com', {
+  schemaVersion: '1.0.0',
+});
+
+const v2 = signSkillWithOptions(dirV2, privPem, 'example.com', {
+  schemaVersion: '1.1.0',
+  previousHash: v1.skill_hash,
+});
+```
+
+### Go
+
+```go
+import "github.com/ThirdKeyAi/schemapin/go/pkg/skill"
+
+v1, _ := skill.SignSkillWithOptions(dirV1, privPEM, "example.com", skill.SignOptions{
+    SchemaVersion: "1.0.0",
+})
+
+v2, _ := skill.SignSkillWithOptions(dirV2, privPEM, "example.com", skill.SignOptions{
+    SchemaVersion: "1.1.0",
+    PreviousHash:  v1.SkillHash,
+})
+```
+
+---
+
+## Verifying lineage
+
+`verify_skill_offline` (and the per-language equivalents) automatically copy `schema_version` and `previous_hash` onto the result for inspection — no enforcement.
+
+To **enforce** that a new signature legitimately succeeds a known-good previous one, call `verify_chain` (or the language equivalent) explicitly. Both signatures must already have been cryptographically verified independently — the chain check is pure metadata; it doesn't re-evaluate any signatures.
+
+### Rust
+
+```rust
+use schemapin::skill::{verify_chain, ChainError};
+
+// First, verify v2 cryptographically:
+let v2_result = verify_skill_offline(&dir_v2, &discovery, None, None, None, Some("tool"));
+assert!(v2_result.valid);
+
+// Then enforce the chain against the trusted predecessor:
+match verify_chain(&v2_sig, &v1_sig) {
+    Ok(()) => { /* roll forward */ }
+    Err(ChainError::NoPreviousHash) => {
+        // v2 doesn't claim a predecessor. Treat as suspicious for
+        // tools that previously had a chain.
+    }
+    Err(ChainError::Mismatch { expected, got }) => {
+        // v2 claims a different predecessor than the one we trust.
+        // Likely an unauthorized substitution.
+    }
+}
+```
+
+### Python
+
+```python
+from schemapin.skill import verify_chain, ChainError
+
+try:
+    verify_chain(v2_sig, v1_sig)
+except ChainError as e:
+    # ChainError is a subclass of ValueError; message includes the mismatch
+    log.warning("chain failed: %s", e)
+```
+
+### JavaScript
+
+```javascript
+import { verifyChain, ChainError } from 'schemapin';
+
+try {
+    verifyChain(v2Sig, v1Sig);
+} catch (err) {
+    if (err instanceof ChainError) {
+        // err.kind is 'no_previous_hash' or 'mismatch'
+    } else {
+        throw err;
+    }
+}
+```
+
+### Go
+
+```go
+import (
+    "errors"
+    "github.com/ThirdKeyAi/schemapin/go/pkg/skill"
+)
+
+if err := skill.VerifyChain(v2Sig, v1Sig); err != nil {
+    var ce *skill.ChainError
+    if errors.As(err, &ce) {
+        switch ce.Kind {
+        case skill.ChainErrorNoPreviousHash:
+            // ...
+        case skill.ChainErrorMismatch:
+            // ce.Expected, ce.Got
+        }
+    }
+}
+```
+
+---
+
+## Operational pattern
+
+A publisher rolling a chain SHOULD:
+
+1. After signing v_n, record the resulting `skill_hash` in their build pipeline.
+2. When signing v_{n+1}, set `previous_hash = skill_hash_of_v_n`.
+3. Distribute v_{n+1} so verifiers can resolve v_n (e.g., publish both, or include v_n's hash in a registry).
+
+A verifier enforcing the chain SHOULD maintain a per-tool `latest_known_hash` next to the TOFU public-key pin. On encountering a new signature with `previous_hash`:
+
+| State | Action |
+|-------|--------|
+| matches `latest_known_hash` | accept, roll forward |
+| empty | depends on policy: prompt, accept-with-warning, or reject for tools that previously chained |
+| present but mismatch | likely unauthorized substitution — fail or prompt the operator |
+
+This pairs cleanly with `schema_version`: enforce monotonic version progression as a separate policy layer (e.g., refuse downgrades).
+
+---
+
+## Why this defends against rug pulls
+
+A rug pull is an unauthorized substitution of a tool's behavior under the same identity. Without lineage:
+
+- Attacker compromises the publisher's signing key (or the publisher acts in bad faith).
+- Attacker re-signs a tampered schema with the same `signer_kid`. The TOFU pin still matches.
+- Verifier accepts the new schema as authentic. Behavior changes silently.
+
+With lineage, the rug-pull either:
+
+- **Omits `previous_hash`** — discoverable: a verifier that previously saw chained signatures can fail or prompt on the missing field.
+- **Lies about `previous_hash`** — verifier compares against its `latest_known_hash` and catches the mismatch.
+
+Lineage doesn't prevent compromise of the signing key — but it gives operators a chance to *notice* a substitution rather than silently load it.
+
+---
+
+## Backward compatibility
+
+| Verifier ↓ / Signer → | v1.3 sig | v1.4 sig (no lineage) | v1.4 sig (with lineage) |
+|-----------------------|----------|------------------------|--------------------------|
+| **v1.3 verifier** | works | works (fields ignored) | works (fields ignored) |
+| **v1.4 verifier** | works (no lineage) | works (no lineage) | lineage surfaced; chain enforcement opt-in |
+
+Both directions are intentional — v1.4 is purely additive. There is no situation where bumping a verifier or a signer to v1.4 breaks an existing deployment.
+
+---
+
+## See also
+
+- [Technical specification §18](https://github.com/ThirdKeyAI/SchemaPin/blob/main/TECHNICAL_SPECIFICATION.md#18-schema-version-binding-v14)
+- [Signature expiration](signature-expiration.md) — the other v1.4-alpha.1 feature
+- [DNS TXT cross-verification](dns-txt.md) — second-channel anti-substitution defense, complementary to lineage
+- [Revocation](revocation.md) — what to do *after* you discover a substitution

--- a/go/internal/version/version.go
+++ b/go/internal/version/version.go
@@ -2,7 +2,7 @@
 package version
 
 // Version is set at build time via ldflags
-var Version = "1.4.0-alpha.1"
+var Version = "1.4.0-alpha.2"
 
 // GetVersion returns the current version string
 func GetVersion() string {

--- a/go/pkg/skill/lineage_test.go
+++ b/go/pkg/skill/lineage_test.go
@@ -1,0 +1,253 @@
+package skill
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSignWithSchemaVersionWritesField confirms a non-empty SchemaVersion is
+// written and bumps schemapin_version to "1.4".
+func TestSignWithSchemaVersionWritesField(t *testing.T) {
+	privPEM, _ := makeKeypair(t)
+	dir := createSkillDir(t, map[string]string{
+		"SKILL.md": "---\nname: ver\n---\n",
+	})
+
+	sig, err := SignSkillWithOptions(dir, privPEM, "example.com", SignOptions{
+		SchemaVersion: "2.1.0",
+	})
+	if err != nil {
+		t.Fatalf("SignSkillWithOptions: %v", err)
+	}
+	if sig.SchemaVersion != "2.1.0" {
+		t.Fatalf("SchemaVersion = %q, want 2.1.0", sig.SchemaVersion)
+	}
+	if sig.SchemapinVersion != "1.4" {
+		t.Fatalf("SchemapinVersion = %q, want 1.4", sig.SchemapinVersion)
+	}
+
+	onDisk, err := LoadSignature(dir)
+	if err != nil {
+		t.Fatalf("LoadSignature: %v", err)
+	}
+	if onDisk.SchemaVersion != "2.1.0" {
+		t.Fatalf("on-disk SchemaVersion = %q, want 2.1.0", onDisk.SchemaVersion)
+	}
+}
+
+// TestSignWithoutLineageOmitsFields confirms v1.3 sigs (no lineage opts) keep
+// the schema_version and previous_hash fields out of the JSON entirely.
+func TestSignWithoutLineageOmitsFields(t *testing.T) {
+	privPEM, _ := makeKeypair(t)
+	dir := createSkillDir(t, map[string]string{
+		"SKILL.md": "---\nname: nv\n---\n",
+	})
+
+	sig, err := SignSkill(dir, privPEM, "example.com", "", "")
+	if err != nil {
+		t.Fatalf("SignSkill: %v", err)
+	}
+	if sig.SchemaVersion != "" {
+		t.Fatalf("SchemaVersion should be empty, got %q", sig.SchemaVersion)
+	}
+	if sig.PreviousHash != "" {
+		t.Fatalf("PreviousHash should be empty, got %q", sig.PreviousHash)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, SignatureFilename))
+	if err != nil {
+		t.Fatalf("read sig file: %v", err)
+	}
+	if strings.Contains(string(raw), "schema_version") {
+		t.Fatalf("JSON should omit schema_version, got %s", raw)
+	}
+	if strings.Contains(string(raw), "previous_hash") {
+		t.Fatalf("JSON should omit previous_hash, got %s", raw)
+	}
+}
+
+// TestSignWithPreviousHashWritesField confirms PreviousHash is written and
+// bumps schemapin_version to "1.4".
+func TestSignWithPreviousHashWritesField(t *testing.T) {
+	privPEM, _ := makeKeypair(t)
+	dir := createSkillDir(t, map[string]string{
+		"SKILL.md": "---\nname: ch\n---\n",
+	})
+
+	sig, err := SignSkillWithOptions(dir, privPEM, "example.com", SignOptions{
+		PreviousHash: "sha256:abcdef",
+	})
+	if err != nil {
+		t.Fatalf("SignSkillWithOptions: %v", err)
+	}
+	if sig.PreviousHash != "sha256:abcdef" {
+		t.Fatalf("PreviousHash = %q, want sha256:abcdef", sig.PreviousHash)
+	}
+	if sig.SchemapinVersion != "1.4" {
+		t.Fatalf("SchemapinVersion = %q, want 1.4", sig.SchemapinVersion)
+	}
+}
+
+// TestVerifyChainMatches accepts a valid lineage.
+func TestVerifyChainMatches(t *testing.T) {
+	privPEM, _ := makeKeypair(t)
+	dir1 := createSkillDir(t, map[string]string{
+		"SKILL.md": "---\nname: v1\n---\n",
+	})
+	v1, err := SignSkill(dir1, privPEM, "example.com", "", "")
+	if err != nil {
+		t.Fatalf("SignSkill v1: %v", err)
+	}
+
+	dir2 := createSkillDir(t, map[string]string{
+		"SKILL.md": "---\nname: v2\n---\n",
+	})
+	v2, err := SignSkillWithOptions(dir2, privPEM, "example.com", SignOptions{
+		PreviousHash: v1.SkillHash,
+	})
+	if err != nil {
+		t.Fatalf("SignSkillWithOptions v2: %v", err)
+	}
+
+	if err := VerifyChain(v2, v1); err != nil {
+		t.Fatalf("VerifyChain: %v", err)
+	}
+}
+
+// TestVerifyChainNoPreviousHashErrors rejects a sig without PreviousHash.
+func TestVerifyChainNoPreviousHashErrors(t *testing.T) {
+	privPEM, _ := makeKeypair(t)
+	dir1 := createSkillDir(t, map[string]string{
+		"SKILL.md": "---\nname: v1\n---\n",
+	})
+	dir2 := createSkillDir(t, map[string]string{
+		"SKILL.md": "---\nname: v2\n---\n",
+	})
+	v1, err := SignSkill(dir1, privPEM, "example.com", "", "")
+	if err != nil {
+		t.Fatalf("SignSkill v1: %v", err)
+	}
+	v2, err := SignSkill(dir2, privPEM, "example.com", "", "")
+	if err != nil {
+		t.Fatalf("SignSkill v2: %v", err)
+	}
+
+	err = VerifyChain(v2, v1)
+	var ce *ChainError
+	if !errors.As(err, &ce) {
+		t.Fatalf("expected *ChainError, got %T: %v", err, err)
+	}
+	if ce.Kind != ChainErrorNoPreviousHash {
+		t.Fatalf("Kind = %v, want ChainErrorNoPreviousHash", ce.Kind)
+	}
+}
+
+// TestVerifyChainMismatchErrors rejects a sig whose PreviousHash points elsewhere.
+func TestVerifyChainMismatchErrors(t *testing.T) {
+	privPEM, _ := makeKeypair(t)
+	dir1 := createSkillDir(t, map[string]string{
+		"SKILL.md": "---\nname: v1\n---\n",
+	})
+	dir2 := createSkillDir(t, map[string]string{
+		"SKILL.md": "---\nname: v2\n---\n",
+	})
+	v1, err := SignSkill(dir1, privPEM, "example.com", "", "")
+	if err != nil {
+		t.Fatalf("SignSkill v1: %v", err)
+	}
+	v2, err := SignSkillWithOptions(dir2, privPEM, "example.com", SignOptions{
+		PreviousHash: "sha256:not-the-real-prior-hash",
+	})
+	if err != nil {
+		t.Fatalf("SignSkillWithOptions v2: %v", err)
+	}
+
+	err = VerifyChain(v2, v1)
+	var ce *ChainError
+	if !errors.As(err, &ce) {
+		t.Fatalf("expected *ChainError, got %T: %v", err, err)
+	}
+	if ce.Kind != ChainErrorMismatch {
+		t.Fatalf("Kind = %v, want ChainErrorMismatch", ce.Kind)
+	}
+	if ce.Expected != v1.SkillHash {
+		t.Fatalf("Expected = %q, want %q", ce.Expected, v1.SkillHash)
+	}
+	if ce.Got != "sha256:not-the-real-prior-hash" {
+		t.Fatalf("Got = %q, want sha256:not-the-real-prior-hash", ce.Got)
+	}
+}
+
+// TestVerifySkillOfflineSurfacesLineage confirms lineage metadata flows from
+// the signature into VerificationResult fields.
+func TestVerifySkillOfflineSurfacesLineage(t *testing.T) {
+	privPEM, pubPEM := makeKeypair(t)
+	dir := createSkillDir(t, map[string]string{
+		"SKILL.md": "---\nname: lin\n---\n",
+	})
+	if _, err := SignSkillWithOptions(dir, privPEM, "example.com", SignOptions{
+		SchemaVersion: "3.2.1",
+		PreviousHash:  "sha256:deadbeef",
+	}); err != nil {
+		t.Fatalf("SignSkillWithOptions: %v", err)
+	}
+
+	disc := makeDiscovery(pubPEM)
+	result := VerifySkillOffline(dir, disc, nil, nil, nil, "lin")
+	if !result.Valid {
+		t.Fatalf("expected Valid=true, got %+v", result)
+	}
+	if result.SchemaVersion != "3.2.1" {
+		t.Fatalf("SchemaVersion = %q, want 3.2.1", result.SchemaVersion)
+	}
+	if result.PreviousHash != "sha256:deadbeef" {
+		t.Fatalf("PreviousHash = %q, want sha256:deadbeef", result.PreviousHash)
+	}
+}
+
+// TestCombinedV14FieldsRoundTrip exercises all v1.4 alpha.{1,2} optional
+// fields together: expires_at + schema_version + previous_hash.
+func TestCombinedV14FieldsRoundTrip(t *testing.T) {
+	privPEM, _ := makeKeypair(t)
+	dir := createSkillDir(t, map[string]string{
+		"SKILL.md": "---\nname: combo\n---\n",
+	})
+	sig, err := SignSkillWithOptions(dir, privPEM, "example.com", SignOptions{
+		ExpiresIn:     180 * 24 * time.Hour,
+		SchemaVersion: "1.0.0",
+		PreviousHash:  "sha256:cafebabe",
+	})
+	if err != nil {
+		t.Fatalf("SignSkillWithOptions: %v", err)
+	}
+	if sig.SchemapinVersion != "1.4" {
+		t.Fatalf("SchemapinVersion = %q, want 1.4", sig.SchemapinVersion)
+	}
+	if sig.ExpiresAt == "" {
+		t.Fatalf("ExpiresAt should be set")
+	}
+	if sig.SchemaVersion != "1.0.0" {
+		t.Fatalf("SchemaVersion = %q, want 1.0.0", sig.SchemaVersion)
+	}
+	if sig.PreviousHash != "sha256:cafebabe" {
+		t.Fatalf("PreviousHash = %q, want sha256:cafebabe", sig.PreviousHash)
+	}
+
+	onDisk, err := LoadSignature(dir)
+	if err != nil {
+		t.Fatalf("LoadSignature: %v", err)
+	}
+	if onDisk.ExpiresAt != sig.ExpiresAt {
+		t.Fatalf("on-disk ExpiresAt = %q, want %q", onDisk.ExpiresAt, sig.ExpiresAt)
+	}
+	if onDisk.SchemaVersion != "1.0.0" {
+		t.Fatalf("on-disk SchemaVersion = %q, want 1.0.0", onDisk.SchemaVersion)
+	}
+	if onDisk.PreviousHash != "sha256:cafebabe" {
+		t.Fatalf("on-disk PreviousHash = %q, want sha256:cafebabe", onDisk.PreviousHash)
+	}
+}

--- a/go/pkg/skill/skill.go
+++ b/go/pkg/skill/skill.go
@@ -46,9 +46,13 @@ const (
 
 // SkillSignature represents the JSON structure of a .schemapin.sig file.
 //
-// ExpiresAt is an optional v1.4 field. When present, verifiers treat
-// signatures past the expiration as degraded (warning) rather than a hard
-// failure -- see VerifySkillOffline.
+// Optional v1.4 fields:
+//   - ExpiresAt: when present, verifiers treat signatures past the expiration
+//     as degraded (warning) rather than a hard failure -- see VerifySkillOffline.
+//   - SchemaVersion: caller-supplied semver string identifying *this* version
+//     of the signed artifact. Surfaced via VerificationResult for policy use.
+//   - PreviousHash: sha256:<hex> of the prior signed version's SkillHash,
+//     forming a hash chain. Pair with VerifyChain.
 type SkillSignature struct {
 	SchemapinVersion string            `json:"schemapin_version"`
 	SkillName        string            `json:"skill_name"`
@@ -56,6 +60,8 @@ type SkillSignature struct {
 	Signature        string            `json:"signature"`
 	SignedAt         string            `json:"signed_at"`
 	ExpiresAt        string            `json:"expires_at,omitempty"`
+	SchemaVersion    string            `json:"schema_version,omitempty"`
+	PreviousHash     string            `json:"previous_hash,omitempty"`
 	Domain           string            `json:"domain"`
 	SignerKid        string            `json:"signer_kid"`
 	FileManifest     map[string]string `json:"file_manifest"`
@@ -79,6 +85,13 @@ type SignOptions struct {
 	// bumped to "1.4". A zero value (the default) writes no expires_at and
 	// keeps the version at "1.3".
 	ExpiresIn time.Duration
+	// SchemaVersion is a caller-supplied semver string identifying *this*
+	// version of the signed artifact (v1.4 alpha.2). Empty omits the field.
+	SchemaVersion string
+	// PreviousHash is sha256:<hex> of the prior signed version's SkillHash,
+	// forming a hash chain (v1.4 alpha.2). Pair with VerifyChain at verify
+	// time. Empty omits the field.
+	PreviousHash string
 }
 
 // TamperedFiles holds the result of comparing two file manifests.
@@ -309,10 +322,15 @@ func SignSkillWithOptions(skillDir, privateKeyPEM, domain string, options SignOp
 	}
 
 	now := time.Now().UTC().Truncate(time.Second)
-	version := schemapinVersionV13
 	expiresAt := ""
 	if options.ExpiresIn > 0 {
 		expiresAt = now.Add(options.ExpiresIn).UTC().Format(time.RFC3339)
+	}
+
+	// Any v1.4 optional field bumps the version stamp; pure v1.3 sigs stay
+	// "1.3" for byte-stable backward compatibility.
+	version := schemapinVersionV13
+	if expiresAt != "" || options.SchemaVersion != "" || options.PreviousHash != "" {
 		version = schemapinVersionV14
 	}
 
@@ -323,6 +341,8 @@ func SignSkillWithOptions(skillDir, privateKeyPEM, domain string, options SignOp
 		Signature:        signatureB64,
 		SignedAt:         now.Format(time.RFC3339),
 		ExpiresAt:        expiresAt,
+		SchemaVersion:    options.SchemaVersion,
+		PreviousHash:     options.PreviousHash,
 		Domain:           domain,
 		SignerKid:        signerKid,
 		FileManifest:     manifest,
@@ -467,7 +487,10 @@ func VerifySkillOffline(
 
 	// v1.4: apply optional signature expiration check. No-op when ExpiresAt
 	// is empty; otherwise may set Expired/ExpiresAt and append a warning.
-	return result.WithExpirationCheck(sig.ExpiresAt)
+	result = result.WithExpirationCheck(sig.ExpiresAt)
+	// v1.4 alpha.2: surface lineage metadata (informational; chain enforcement
+	// is opt-in via VerifyChain).
+	return result.WithLineageMetadata(sig.SchemaVersion, sig.PreviousHash)
 }
 
 // VerifySkillWithResolver verifies a signed skill folder using a resolver
@@ -523,4 +546,62 @@ func DetectTamperedFiles(current, signed map[string]string) *TamperedFiles {
 	sort.Strings(result.Removed)
 
 	return result
+}
+
+// ChainErrorKind enumerates VerifyChain failure modes.
+type ChainErrorKind int
+
+const (
+	// ChainErrorNoPreviousHash indicates current.PreviousHash is empty.
+	ChainErrorNoPreviousHash ChainErrorKind = iota + 1
+	// ChainErrorMismatch indicates current.PreviousHash != previous.SkillHash.
+	ChainErrorMismatch
+)
+
+// ChainError is returned by VerifyChain on lineage failure.
+type ChainError struct {
+	Kind     ChainErrorKind
+	Expected string
+	Got      string
+}
+
+func (e *ChainError) Error() string {
+	switch e.Kind {
+	case ChainErrorNoPreviousHash:
+		return "current signature has no previous_hash field"
+	case ChainErrorMismatch:
+		return fmt.Sprintf(
+			"previous_hash mismatch: current.previous_hash = %s, previous.skill_hash = %s",
+			e.Got, e.Expected,
+		)
+	default:
+		return "unknown chain error"
+	}
+}
+
+// VerifyChain verifies that current is the legitimate successor of previous
+// via the previous_hash lineage chain (v1.4 alpha.2).
+//
+// Checks current.PreviousHash == previous.SkillHash.
+//
+// This is a pure-metadata check -- no cryptography is re-evaluated. Both
+// signatures must already be cryptographically verified separately via
+// VerifySkillOffline for the chain check to be meaningful.
+//
+// Use this to defend against rug-pull attacks where an attacker substitutes
+// a schema/skill out-of-band: a legitimate update declares the prior version's
+// hash; an unauthorized substitution either omits previous_hash or points at
+// a hash the verifier has not accepted as a valid ancestor.
+func VerifyChain(current, previous *SkillSignature) error {
+	if current.PreviousHash == "" {
+		return &ChainError{Kind: ChainErrorNoPreviousHash}
+	}
+	if current.PreviousHash != previous.SkillHash {
+		return &ChainError{
+			Kind:     ChainErrorMismatch,
+			Expected: previous.SkillHash,
+			Got:      current.PreviousHash,
+		}
+	}
+	return nil
 }

--- a/go/pkg/verification/verification.go
+++ b/go/pkg/verification/verification.go
@@ -65,6 +65,14 @@ type VerificationResult struct {
 	Expired bool `json:"expired,omitempty"`
 	// ExpiresAt mirrors the signature's expires_at value when present.
 	ExpiresAt string `json:"expires_at,omitempty"`
+	// SchemaVersion (v1.4 alpha.2) mirrors the signature's schema_version
+	// field when present -- a caller-supplied semver string identifying
+	// *this* version of the artifact, surfaced for policy use.
+	SchemaVersion string `json:"schema_version,omitempty"`
+	// PreviousHash (v1.4 alpha.2) mirrors the signature's previous_hash
+	// field when present -- sha256:<hex> of the prior signed version's
+	// SkillHash. Pair with skill.VerifyChain to confirm lineage.
+	PreviousHash string `json:"previous_hash,omitempty"`
 }
 
 // WithExpirationCheck applies a v1.4 signature expiration check to a
@@ -93,6 +101,26 @@ func (r *VerificationResult) WithExpirationCheck(expiresAt string) *Verification
 	if time.Now().UTC().After(ts.UTC()) {
 		r.Expired = true
 		r.Warnings = append(r.Warnings, WarningSignatureExpired)
+	}
+	return r
+}
+
+// WithLineageMetadata copies v1.4 alpha.2 schema_version and previous_hash
+// fields onto a successful VerificationResult and returns the receiver.
+//
+// No semantic enforcement -- these are informational fields callers use for
+// version policy and chain verification (see skill.VerifyChain).
+//
+// The receiver may be nil; in that case it is returned unchanged.
+func (r *VerificationResult) WithLineageMetadata(schemaVersion, previousHash string) *VerificationResult {
+	if r == nil {
+		return r
+	}
+	if schemaVersion != "" {
+		r.SchemaVersion = schemaVersion
+	}
+	if previousHash != "" {
+		r.PreviousHash = previousHash
 	}
 	return r
 }

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schemapin",
-  "version": "1.4.0-alpha.1",
+  "version": "1.4.0-alpha.2",
   "description": "Cryptographic schema integrity verification for AI tools",
   "main": "src/index.js",
   "type": "module",

--- a/javascript/src/skill.js
+++ b/javascript/src/skill.js
@@ -195,6 +195,61 @@ export function signSkill(skillDir, privateKeyPem, domain, signerKid = null, ski
 }
 
 /**
+ * v1.4 alpha.2 chain check error.
+ *
+ * Subclass of Error. Distinguish via the `kind` property:
+ *   - `'no_previous_hash'` — current signature has no `previous_hash` field
+ *   - `'mismatch'` — current.previous_hash !== previous.skill_hash
+ */
+export class ChainError extends Error {
+    /**
+     * @param {string} kind - 'no_previous_hash' | 'mismatch'
+     * @param {string} message
+     */
+    constructor(kind, message) {
+        super(message);
+        this.name = 'ChainError';
+        this.kind = kind;
+    }
+}
+
+/**
+ * Verify that `current` is the legitimate successor of `previous` via the
+ * `previous_hash` lineage chain (v1.4 alpha.2).
+ *
+ * Checks `current.previous_hash === previous.skill_hash`.
+ *
+ * This is a pure-metadata check — no cryptography is re-evaluated. Both
+ * signatures must already be cryptographically verified separately via
+ * {@link verifySkillOffline} for the chain check to be meaningful.
+ *
+ * Use this to defend against rug-pull attacks where an attacker substitutes
+ * a schema/skill out-of-band: a legitimate update declares the prior version's
+ * hash; an unauthorized substitution either omits `previous_hash` or points
+ * at a hash the verifier has not accepted as a valid ancestor.
+ *
+ * @param {Object} current - The new signature dict (must have `previous_hash`)
+ * @param {Object} previous - The prior signature dict (must have `skill_hash`)
+ * @throws {ChainError} On chain mismatch or missing `previous_hash`
+ */
+export function verifyChain(current, previous) {
+    const claimed = current.previous_hash;
+    if (claimed === null || claimed === undefined) {
+        throw new ChainError(
+            'no_previous_hash',
+            'current signature has no previous_hash field'
+        );
+    }
+    const expected = previous.skill_hash;
+    if (claimed !== expected) {
+        throw new ChainError(
+            'mismatch',
+            `previous_hash mismatch: current.previous_hash = ${claimed}, previous.skill_hash = ${expected}`
+        );
+    }
+}
+
+/**
  * Canonicalize a skill directory, sign, and write .schemapin.sig with extended
  * options (v1.4+).
  *
@@ -219,7 +274,17 @@ export function signSkill(skillDir, privateKeyPem, domain, signerKid = null, ski
  * @returns {Object} The signature document that was written
  */
 export function signSkillWithOptions(skillDir, privateKeyPem, domain, options = {}) {
-    const { signerKid: optSignerKid = null, skillName: optSkillName = null, expiresIn = null } = options;
+    const {
+        signerKid: optSignerKid = null,
+        skillName: optSkillName = null,
+        expiresIn = null,
+        // v1.4 alpha.2: caller-supplied semver string identifying *this* version
+        // of the signed artifact. Surfaced via VerificationResult for policy use.
+        schemaVersion = null,
+        // v1.4 alpha.2: `sha256:<hex>` of the prior signed version's
+        // `skill_hash`, forming a hash chain. Pair with `verifyChain`.
+        previousHash = null
+    } = options;
 
     const skillPath = resolve(skillDir);
     const privateKey = KeyManager.loadPrivateKeyPem(privateKeyPem);
@@ -247,42 +312,39 @@ export function signSkillWithOptions(skillDir, privateKeyPem, domain, options = 
         expiresAt = toRfc3339Seconds(new Date(now.getTime() + expiresIn));
     }
 
-    const version = expiresAt !== null ? SCHEMAPIN_VERSION_V14 : SCHEMAPIN_VERSION_V13;
+    // Any v1.4 optional field bumps the version stamp; pure v1.3 sigs stay
+    // "1.3" for byte-stable backward compatibility.
+    const usesV14Field =
+        expiresAt !== null
+        || (schemaVersion !== null && schemaVersion !== undefined)
+        || (previousHash !== null && previousHash !== undefined);
+    const version = usesV14Field ? SCHEMAPIN_VERSION_V14 : SCHEMAPIN_VERSION_V13;
 
-    const sigDoc = {
+    // Build the document in canonical field order. Optional v1.4 fields slot
+    // between `signed_at` and `domain`.
+    const ordered = {
         schemapin_version: version,
         skill_name: skillName,
         skill_hash: `sha256:${rootHash.toString('hex')}`,
         signature: signatureB64,
-        signed_at: toRfc3339Seconds(now),
-        domain: domain,
-        signer_kid: signerKid,
-        file_manifest: manifest
+        signed_at: toRfc3339Seconds(now)
     };
     if (expiresAt !== null) {
-        // Insert expires_at after signed_at to keep field order stable.
-        sigDoc.expires_at = expiresAt;
-        // Re-serialize in the documented field order.
-        const ordered = {
-            schemapin_version: sigDoc.schemapin_version,
-            skill_name: sigDoc.skill_name,
-            skill_hash: sigDoc.skill_hash,
-            signature: sigDoc.signature,
-            signed_at: sigDoc.signed_at,
-            expires_at: sigDoc.expires_at,
-            domain: sigDoc.domain,
-            signer_kid: sigDoc.signer_kid,
-            file_manifest: sigDoc.file_manifest
-        };
-        const sigPath = join(skillPath, SIGNATURE_FILENAME);
-        writeFileSync(sigPath, JSON.stringify(ordered, null, 2) + '\n', 'utf-8');
-        return ordered;
+        ordered.expires_at = expiresAt;
     }
+    if (schemaVersion !== null && schemaVersion !== undefined) {
+        ordered.schema_version = schemaVersion;
+    }
+    if (previousHash !== null && previousHash !== undefined) {
+        ordered.previous_hash = previousHash;
+    }
+    ordered.domain = domain;
+    ordered.signer_kid = signerKid;
+    ordered.file_manifest = manifest;
 
     const sigPath = join(skillPath, SIGNATURE_FILENAME);
-    writeFileSync(sigPath, JSON.stringify(sigDoc, null, 2) + '\n', 'utf-8');
-
-    return sigDoc;
+    writeFileSync(sigPath, JSON.stringify(ordered, null, 2) + '\n', 'utf-8');
+    return ordered;
 }
 
 /**
@@ -416,6 +478,15 @@ export function verifySkillOffline(skillDir, discovery, signatureData = null, re
     // v1.4: apply signature expiration check (degraded, not failed).
     if (signatureData.expires_at !== null && signatureData.expires_at !== undefined) {
         applyExpirationCheck(resultObj, signatureData.expires_at);
+    }
+
+    // v1.4 alpha.2: surface lineage metadata (informational; chain enforcement
+    // is opt-in via verifyChain).
+    if (signatureData.schema_version !== null && signatureData.schema_version !== undefined) {
+        resultObj.schema_version = signatureData.schema_version;
+    }
+    if (signatureData.previous_hash !== null && signatureData.previous_hash !== undefined) {
+        resultObj.previous_hash = signatureData.previous_hash;
     }
 
     return resultObj;

--- a/javascript/tests/skill.test.js
+++ b/javascript/tests/skill.test.js
@@ -13,7 +13,7 @@ import { ErrorCode, KeyPinStore } from '../src/verification.js';
 import {
     SIGNATURE_FILENAME, canonicalizeSkill, parseSkillName, loadSignature,
     signSkill, signSkillWithOptions, verifySkillOffline, verifySkillOfflineWithDns,
-    detectTamperedFiles
+    detectTamperedFiles, verifyChain, ChainError
 } from '../src/skill.js';
 
 // ---------------------------------------------------------------------------
@@ -750,6 +750,165 @@ describe('verifySkillOfflineWithDns (v1.4)', () => {
                 skillDir, makeDiscovery(publicKey), null, null, null, 'nodns', null
             );
             assert.equal(result.valid, true);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// v1.4 alpha.2: schema_version + previous_hash lineage chain
+// ---------------------------------------------------------------------------
+
+describe('Schema version binding (v1.4 alpha.2)', () => {
+    it('writes schema_version when set and bumps schemapin_version to 1.4', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'skill-test-'));
+        try {
+            const { privateKey } = makeKeypair();
+            const skillDir = join(dir, 'skill');
+            createSkillDir(skillDir, { 'SKILL.md': '---\nname: ver\n---\n' });
+            const sig = signSkillWithOptions(skillDir, privateKey, 'example.com', {
+                schemaVersion: '2.1.0'
+            });
+            assert.equal(sig.schema_version, '2.1.0');
+            assert.equal(sig.schemapin_version, '1.4');
+            const onDisk = loadSignature(skillDir);
+            assert.equal(onDisk.schema_version, '2.1.0');
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('omits schema_version and previous_hash when not set', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'skill-test-'));
+        try {
+            const { privateKey } = makeKeypair();
+            const skillDir = join(dir, 'skill');
+            createSkillDir(skillDir, { 'SKILL.md': '---\nname: noversion\n---\n' });
+            const sig = signSkill(skillDir, privateKey, 'example.com');
+            assert.equal(sig.schema_version, undefined);
+            assert.equal(sig.previous_hash, undefined);
+            const raw = readFileSync(join(skillDir, SIGNATURE_FILENAME), 'utf-8');
+            assert.ok(!raw.includes('schema_version'), 'JSON should omit schema_version');
+            assert.ok(!raw.includes('previous_hash'), 'JSON should omit previous_hash');
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('writes previous_hash when set and bumps schemapin_version to 1.4', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'skill-test-'));
+        try {
+            const { privateKey } = makeKeypair();
+            const skillDir = join(dir, 'skill');
+            createSkillDir(skillDir, { 'SKILL.md': '---\nname: chained\n---\n' });
+            const sig = signSkillWithOptions(skillDir, privateKey, 'example.com', {
+                previousHash: 'sha256:abcdef'
+            });
+            assert.equal(sig.previous_hash, 'sha256:abcdef');
+            assert.equal(sig.schemapin_version, '1.4');
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('verifyChain accepts a valid lineage', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'skill-test-'));
+        try {
+            const { privateKey } = makeKeypair();
+            const s1 = createSkillDir(join(dir, 'v1'), { 'SKILL.md': '---\nname: v1\n---\n' });
+            const v1 = signSkill(s1, privateKey, 'example.com');
+
+            const s2 = createSkillDir(join(dir, 'v2'), { 'SKILL.md': '---\nname: v2\n---\n' });
+            const v2 = signSkillWithOptions(s2, privateKey, 'example.com', {
+                previousHash: v1.skill_hash
+            });
+
+            assert.doesNotThrow(() => verifyChain(v2, v1));
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('verifyChain throws ChainError when previous_hash is missing', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'skill-test-'));
+        try {
+            const { privateKey } = makeKeypair();
+            const s1 = createSkillDir(join(dir, 'v1'), { 'SKILL.md': '---\nname: v1\n---\n' });
+            const s2 = createSkillDir(join(dir, 'v2'), { 'SKILL.md': '---\nname: v2\n---\n' });
+            const v1 = signSkill(s1, privateKey, 'example.com');
+            const v2 = signSkill(s2, privateKey, 'example.com');
+            assert.throws(
+                () => verifyChain(v2, v1),
+                (err) => err instanceof ChainError && err.kind === 'no_previous_hash'
+            );
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('verifyChain throws ChainError on hash mismatch', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'skill-test-'));
+        try {
+            const { privateKey } = makeKeypair();
+            const s1 = createSkillDir(join(dir, 'v1'), { 'SKILL.md': '---\nname: v1\n---\n' });
+            const s2 = createSkillDir(join(dir, 'v2'), { 'SKILL.md': '---\nname: v2\n---\n' });
+            const v1 = signSkill(s1, privateKey, 'example.com');
+            const v2 = signSkillWithOptions(s2, privateKey, 'example.com', {
+                previousHash: 'sha256:not-the-real-prior-hash'
+            });
+            assert.throws(
+                () => verifyChain(v2, v1),
+                (err) => err instanceof ChainError
+                    && err.kind === 'mismatch'
+                    && err.message.includes(v1.skill_hash)
+            );
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('verifySkillOffline surfaces lineage metadata', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'skill-test-'));
+        try {
+            const { privateKey, publicKey } = makeKeypair();
+            const skillDir = join(dir, 'skill');
+            createSkillDir(skillDir, { 'SKILL.md': '---\nname: surfaced\n---\n' });
+            signSkillWithOptions(skillDir, privateKey, 'example.com', {
+                schemaVersion: '3.2.1',
+                previousHash: 'sha256:deadbeef'
+            });
+            const result = verifySkillOffline(
+                skillDir, makeDiscovery(publicKey), null, null, new KeyPinStore(), 'surfaced'
+            );
+            assert.equal(result.valid, true);
+            assert.equal(result.schema_version, '3.2.1');
+            assert.equal(result.previous_hash, 'sha256:deadbeef');
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('combined v1.4 fields all round-trip', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'skill-test-'));
+        try {
+            const { privateKey } = makeKeypair();
+            const skillDir = join(dir, 'skill');
+            createSkillDir(skillDir, { 'SKILL.md': '---\nname: combo\n---\n' });
+            const sig = signSkillWithOptions(skillDir, privateKey, 'example.com', {
+                expiresIn: 180 * 24 * 60 * 60 * 1000, // 180 days in ms
+                schemaVersion: '1.0.0',
+                previousHash: 'sha256:cafebabe'
+            });
+            assert.equal(sig.schemapin_version, '1.4');
+            assert.ok(typeof sig.expires_at === 'string');
+            assert.equal(sig.schema_version, '1.0.0');
+            assert.equal(sig.previous_hash, 'sha256:cafebabe');
+
+            const onDisk = loadSignature(skillDir);
+            assert.equal(onDisk.expires_at, sig.expires_at);
+            assert.equal(onDisk.schema_version, '1.0.0');
+            assert.equal(onDisk.previous_hash, 'sha256:cafebabe');
         } finally {
             rmSync(dir, { recursive: true, force: true });
         }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schemapin"
-version = "1.4.0a1"
+version = "1.4.0a2"
 description = "Cryptographic schema integrity verification for AI tools"
 readme = "README.md"
 license = {text = "MIT"}

--- a/python/schemapin/__init__.py
+++ b/python/schemapin/__init__.py
@@ -62,7 +62,7 @@ from .verification import (
     verify_schema_with_resolver,
 )
 
-__version__ = "1.4.0a1"
+__version__ = "1.4.0a2"
 __all__ = [
     "SchemaPinCore",
     "KeyManager",

--- a/python/schemapin/skill.py
+++ b/python/schemapin/skill.py
@@ -55,6 +55,12 @@ class SignOptions:
     signer_kid: Optional[str] = None
     skill_name: Optional[str] = None
     expires_in: Optional[timedelta] = None
+    # v1.4 alpha.2: caller-supplied semver string identifying *this* version of
+    # the signed artifact. Surfaced via VerificationResult for policy use.
+    schema_version: Optional[str] = None
+    # v1.4 alpha.2: ``sha256:<hex>`` of the prior signed version's
+    # ``skill_hash``, forming a hash chain. Pair with :func:`verify_chain`.
+    previous_hash: Optional[str] = None
 
 
 class SkillSigner:
@@ -229,9 +235,12 @@ class SkillSigner:
         if options.expires_in is not None:
             expires_at = _format_rfc3339(now + options.expires_in)
 
-        version = (
-            SCHEMAPIN_VERSION_V1_4 if expires_at is not None else SCHEMAPIN_VERSION
+        uses_v1_4_field = (
+            expires_at is not None
+            or options.schema_version is not None
+            or options.previous_hash is not None
         )
+        version = SCHEMAPIN_VERSION_V1_4 if uses_v1_4_field else SCHEMAPIN_VERSION
 
         sig_doc: Dict[str, Any] = {
             "schemapin_version": version,
@@ -243,10 +252,14 @@ class SkillSigner:
             "signer_kid": signer_kid,
             "file_manifest": manifest,
         }
-        # Only emit ``expires_at`` when set, so v1.3 verifiers see an
+        # Only emit v1.4 optional fields when set, so v1.3 verifiers see an
         # unchanged document on the wire.
         if expires_at is not None:
             sig_doc["expires_at"] = expires_at
+        if options.schema_version is not None:
+            sig_doc["schema_version"] = options.schema_version
+        if options.previous_hash is not None:
+            sig_doc["previous_hash"] = options.previous_hash
 
         sig_path = skill_path / SIGNATURE_FILENAME
         sig_path.write_text(
@@ -367,7 +380,8 @@ class SkillSigner:
                 error_message="Signature verification failed",
             )
 
-        # Step 7: Return success, applying optional v1.4 expiration check.
+        # Step 7: Return success, applying optional v1.4 expiration check
+        # and surfacing lineage metadata (schema_version + previous_hash).
         developer_name = discovery.get("developer_name")
         result = VerificationResult(
             valid=True,
@@ -375,7 +389,11 @@ class SkillSigner:
             developer_name=developer_name,
             key_pinning=pinning_status,
         )
-        return result.with_expiration_check(signature_data.get("expires_at"))
+        result = result.with_expiration_check(signature_data.get("expires_at"))
+        return result.with_lineage_metadata(
+            signature_data.get("schema_version"),
+            signature_data.get("previous_hash"),
+        )
 
     @staticmethod
     def verify_skill_offline_with_dns(
@@ -499,3 +517,45 @@ def _format_rfc3339(ts: datetime) -> str:
     utc_ts = ts.astimezone(timezone.utc).replace(microsecond=0)
     # ``isoformat`` would emit ``+00:00``; the spec mandates ``Z``.
     return utc_ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class ChainError(ValueError):
+    """Raised by :func:`verify_chain` when the lineage check fails.
+
+    Subclass of :class:`ValueError` so callers can ``except ValueError`` if they
+    don't care about distinguishing chain failures from generic validation.
+    """
+
+
+def verify_chain(current: Dict[str, Any], previous: Dict[str, Any]) -> None:
+    """Verify ``current`` is the legitimate successor of ``previous`` (v1.4 alpha.2).
+
+    Checks ``current["previous_hash"] == previous["skill_hash"]``.
+
+    This is a pure-metadata check -- no cryptography is re-evaluated. Both
+    signatures must already be cryptographically verified separately via
+    :meth:`SkillSigner.verify_skill_offline` for the chain check to be
+    meaningful.
+
+    Use this to defend against rug-pull attacks where an attacker substitutes
+    a schema/skill out-of-band: a legitimate update declares the prior
+    version's hash; an unauthorized substitution either omits ``previous_hash``
+    or points at a hash the verifier has not accepted as a valid ancestor.
+
+    Args:
+        current: The new signature dict (must have ``previous_hash`` set).
+        previous: The prior signature dict (must have ``skill_hash`` set).
+
+    Raises:
+        ChainError: If ``current`` has no ``previous_hash`` field, or if it
+            does not match ``previous["skill_hash"]``.
+    """
+    claimed = current.get("previous_hash")
+    if claimed is None:
+        raise ChainError("current signature has no previous_hash field")
+    expected = previous.get("skill_hash")
+    if claimed != expected:
+        raise ChainError(
+            f"previous_hash mismatch: current.previous_hash = {claimed}, "
+            f"previous.skill_hash = {expected}"
+        )

--- a/python/schemapin/verification.py
+++ b/python/schemapin/verification.py
@@ -51,6 +51,13 @@ class VerificationResult:
     # so callers can use this flag for confidence scoring or policy gating.
     expired: bool = False
     expires_at: Optional[str] = None
+    # v1.4 alpha.2: schema_version + previous_hash lineage metadata, mirrored
+    # from the signature when present. ``schema_version`` is the caller's
+    # semver string identifying *this* version of the artifact. ``previous_hash``
+    # is the ``sha256:<hex>`` of the prior signed version's ``skill_hash``
+    # (pair with ``schemapin.skill.verify_chain`` to confirm lineage).
+    schema_version: Optional[str] = None
+    previous_hash: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize to dictionary."""
@@ -75,6 +82,10 @@ class VerificationResult:
             d["expired"] = True
         if self.expires_at is not None:
             d["expires_at"] = self.expires_at
+        if self.schema_version is not None:
+            d["schema_version"] = self.schema_version
+        if self.previous_hash is not None:
+            d["previous_hash"] = self.previous_hash
         return d
 
     def with_expiration_check(
@@ -104,6 +115,25 @@ class VerificationResult:
         if datetime.now(timezone.utc) > ts:
             self.expired = True
             self.warnings.append("signature_expired")
+        return self
+
+    def with_lineage_metadata(
+        self,
+        schema_version: Optional[str],
+        previous_hash: Optional[str],
+    ) -> "VerificationResult":
+        """Copy v1.4 alpha.2 lineage fields onto this result.
+
+        No semantic enforcement -- these are informational fields callers use
+        for version policy and chain verification (see
+        :func:`schemapin.skill.verify_chain`).
+
+        Returns ``self`` for chaining.
+        """
+        if schema_version is not None:
+            self.schema_version = schema_version
+        if previous_hash is not None:
+            self.previous_hash = previous_hash
         return self
 
 

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = schemapin
-version = 1.4.0a1
+version = 1.4.0a2
 author = ThirdKey
 author_email = contact@thirdkey.ai
 maintainer = Jascha Wanger

--- a/python/tests/test_skill.py
+++ b/python/tests/test_skill.py
@@ -13,7 +13,13 @@ from schemapin.revocation import (
     add_revoked_key,
     build_revocation_document,
 )
-from schemapin.skill import SIGNATURE_FILENAME, SignOptions, SkillSigner
+from schemapin.skill import (
+    SIGNATURE_FILENAME,
+    ChainError,
+    SignOptions,
+    SkillSigner,
+    verify_chain,
+)
 from schemapin.verification import ErrorCode, KeyPinStore
 
 # ---------------------------------------------------------------------------
@@ -697,3 +703,111 @@ class TestSignatureExpiration:
         assert "expires_at" in d
         # Future TTL: ``expired`` False is the default and should be omitted.
         assert "expired" not in d
+
+
+class TestSchemaVersionBinding:
+    """v1.4 alpha.2: schema_version + previous_hash lineage chain."""
+
+    def test_sign_with_schema_version_writes_field(self, tmp_path: Path) -> None:
+        priv_pem, _ = _make_keypair()
+        skill = _create_skill_dir(
+            tmp_path / "skill", {"SKILL.md": "---\nname: ver\n---\n"}
+        )
+        opts = SignOptions(schema_version="2.1.0")
+        sig = SkillSigner.sign_with_options(skill, priv_pem, "example.com", opts)
+        assert sig["schema_version"] == "2.1.0"
+        assert sig["schemapin_version"] == "1.4"
+        on_disk = SkillSigner.load_signature(skill)
+        assert on_disk["schema_version"] == "2.1.0"
+
+    def test_sign_without_lineage_omits_fields(self, tmp_path: Path) -> None:
+        priv_pem, _ = _make_keypair()
+        skill = _create_skill_dir(
+            tmp_path / "skill", {"SKILL.md": "---\nname: nv\n---\n"}
+        )
+        sig = SkillSigner.sign_skill(skill, priv_pem, "example.com")
+        assert "schema_version" not in sig
+        assert "previous_hash" not in sig
+        raw = (skill / SIGNATURE_FILENAME).read_text(encoding="utf-8")
+        assert "schema_version" not in raw
+        assert "previous_hash" not in raw
+
+    def test_sign_with_previous_hash_writes_field(self, tmp_path: Path) -> None:
+        priv_pem, _ = _make_keypair()
+        skill = _create_skill_dir(
+            tmp_path / "skill", {"SKILL.md": "---\nname: ch\n---\n"}
+        )
+        opts = SignOptions(previous_hash="sha256:abcdef")
+        sig = SkillSigner.sign_with_options(skill, priv_pem, "example.com", opts)
+        assert sig["previous_hash"] == "sha256:abcdef"
+        assert sig["schemapin_version"] == "1.4"
+
+    def test_verify_chain_matches(self, tmp_path: Path) -> None:
+        priv_pem, _ = _make_keypair()
+        s1 = _create_skill_dir(tmp_path / "v1", {"SKILL.md": "---\nname: v1\n---\n"})
+        v1 = SkillSigner.sign_skill(s1, priv_pem, "example.com")
+
+        s2 = _create_skill_dir(tmp_path / "v2", {"SKILL.md": "---\nname: v2\n---\n"})
+        opts = SignOptions(previous_hash=v1["skill_hash"])
+        v2 = SkillSigner.sign_with_options(s2, priv_pem, "example.com", opts)
+
+        # Returns None on success
+        assert verify_chain(v2, v1) is None
+
+    def test_verify_chain_no_previous_hash_errors(self, tmp_path: Path) -> None:
+        priv_pem, _ = _make_keypair()
+        s1 = _create_skill_dir(tmp_path / "v1", {"SKILL.md": "---\nname: v1\n---\n"})
+        s2 = _create_skill_dir(tmp_path / "v2", {"SKILL.md": "---\nname: v2\n---\n"})
+        v1 = SkillSigner.sign_skill(s1, priv_pem, "example.com")
+        v2 = SkillSigner.sign_skill(s2, priv_pem, "example.com")
+        with pytest.raises(ChainError, match="no previous_hash"):
+            verify_chain(v2, v1)
+
+    def test_verify_chain_mismatch_errors(self, tmp_path: Path) -> None:
+        priv_pem, _ = _make_keypair()
+        s1 = _create_skill_dir(tmp_path / "v1", {"SKILL.md": "---\nname: v1\n---\n"})
+        s2 = _create_skill_dir(tmp_path / "v2", {"SKILL.md": "---\nname: v2\n---\n"})
+        v1 = SkillSigner.sign_skill(s1, priv_pem, "example.com")
+        opts = SignOptions(previous_hash="sha256:not-the-real-prior-hash")
+        v2 = SkillSigner.sign_with_options(s2, priv_pem, "example.com", opts)
+        with pytest.raises(ChainError, match="mismatch"):
+            verify_chain(v2, v1)
+
+    def test_verify_skill_offline_surfaces_lineage(self, tmp_path: Path) -> None:
+        priv_pem, pub_pem = _make_keypair()
+        skill = _create_skill_dir(
+            tmp_path / "s", {"SKILL.md": "---\nname: lin\n---\n"}
+        )
+        opts = SignOptions(
+            schema_version="3.2.1", previous_hash="sha256:deadbeef"
+        )
+        SkillSigner.sign_with_options(skill, priv_pem, "example.com", opts)
+        result = SkillSigner.verify_skill_offline(
+            skill, _discovery(pub_pem), tool_id="lin"
+        )
+        assert result.valid
+        assert result.schema_version == "3.2.1"
+        assert result.previous_hash == "sha256:deadbeef"
+        d = result.to_dict()
+        assert d["schema_version"] == "3.2.1"
+        assert d["previous_hash"] == "sha256:deadbeef"
+
+    def test_combined_v1_4_fields_round_trip(self, tmp_path: Path) -> None:
+        priv_pem, _ = _make_keypair()
+        skill = _create_skill_dir(
+            tmp_path / "s", {"SKILL.md": "---\nname: combo\n---\n"}
+        )
+        opts = SignOptions(
+            expires_in=timedelta(days=180),
+            schema_version="1.0.0",
+            previous_hash="sha256:cafebabe",
+        )
+        sig = SkillSigner.sign_with_options(skill, priv_pem, "example.com", opts)
+        assert sig["schemapin_version"] == "1.4"
+        assert "expires_at" in sig
+        assert sig["schema_version"] == "1.0.0"
+        assert sig["previous_hash"] == "sha256:cafebabe"
+        on_disk = SkillSigner.load_signature(skill)
+        assert on_disk["expires_at"] == sig["expires_at"]
+        assert on_disk["schema_version"] == "1.0.0"
+        assert on_disk["previous_hash"] == "sha256:cafebabe"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "schemapin"
-version = "1.4.0-alpha.1"
+version = "1.4.0-alpha.2"
 dependencies = [
  "async-trait",
  "base64 0.21.7",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schemapin"
-version = "1.4.0-alpha.1"
+version = "1.4.0-alpha.2"
 edition = "2021"
 rust-version = "1.70"
 description = "Cryptographic schema integrity verification for AI tools - Rust implementation"

--- a/rust/src/skill.rs
+++ b/rust/src/skill.rs
@@ -24,9 +24,15 @@ use crate::verification::{KeyPinningStatus, VerificationResult};
 
 /// Signature metadata written to `.schemapin.sig`.
 ///
-/// `expires_at` is an optional v1.4 field. When present, verifiers treat
-/// signatures past the expiration as *degraded* (warning) rather than a
-/// hard failure — see [`verify_skill_offline`].
+/// Optional v1.4 fields:
+/// - `expires_at` — verifiers past the expiration emit a `signature_expired` warning
+///   (see [`verify_skill_offline`]); they do not fail.
+/// - `schema_version` — caller-supplied semver string identifying *this* version of
+///   the signed artifact (e.g. `"2.1.0"`). Returned via [`crate::verification::VerificationResult`]
+///   so consumers can apply their own version policy.
+/// - `previous_hash` — SHA-256 hash (`sha256:<hex>`) of the *prior* signed version's
+///   `skill_hash`, forming a hash chain. Use [`verify_chain`] to confirm a new signature
+///   descends from a specific prior signature.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SkillSignature {
     pub schemapin_version: String,
@@ -36,6 +42,10 @@ pub struct SkillSignature {
     pub signed_at: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_hash: Option<String>,
     pub domain: String,
     pub signer_kid: String,
     pub file_manifest: BTreeMap<String, String>,
@@ -196,6 +206,12 @@ pub struct SignOptions<'a> {
     pub skill_name: Option<&'a str>,
     /// Time-to-live for the signature. When set, an `expires_at` field is written.
     pub expires_in: Option<chrono::Duration>,
+    /// Caller-supplied semver string identifying *this* version of the signed artifact.
+    /// Written to `schema_version` and surfaced on [`crate::verification::VerificationResult`].
+    pub schema_version: Option<&'a str>,
+    /// `sha256:<hex>` hash of the *prior* signed version's `skill_hash`, forming a chain.
+    /// When set, written to `previous_hash`. Pair with [`verify_chain`] at verify time.
+    pub previous_hash: Option<&'a str>,
 }
 
 impl<'a> SignOptions<'a> {
@@ -215,6 +231,16 @@ impl<'a> SignOptions<'a> {
 
     pub fn with_expires_in(mut self, ttl: chrono::Duration) -> Self {
         self.expires_in = Some(ttl);
+        self
+    }
+
+    pub fn with_schema_version(mut self, version: &'a str) -> Self {
+        self.schema_version = Some(version);
+        self
+    }
+
+    pub fn with_previous_hash(mut self, hash: &'a str) -> Self {
+        self.previous_hash = Some(hash);
         self
     }
 }
@@ -238,6 +264,8 @@ pub fn sign_skill(
             signer_kid,
             skill_name,
             expires_in: None,
+            schema_version: None,
+            previous_hash: None,
         },
     )
 }
@@ -281,7 +309,14 @@ pub fn sign_skill_with_options(
         .expires_in
         .map(|ttl| (now + ttl).to_rfc3339_opts(chrono::SecondsFormat::Secs, true));
 
-    let version = if expires_at.is_some() { "1.4" } else { "1.3" };
+    let schema_version = options.schema_version.map(str::to_string);
+    let previous_hash = options.previous_hash.map(str::to_string);
+
+    // Any v1.4 optional field bumps the version stamp; pure v1.3 sigs stay "1.3"
+    // for byte-stable backward compatibility.
+    let uses_v1_4_field =
+        expires_at.is_some() || schema_version.is_some() || previous_hash.is_some();
+    let version = if uses_v1_4_field { "1.4" } else { "1.3" };
 
     let sig_doc = SkillSignature {
         schemapin_version: version.to_string(),
@@ -290,6 +325,8 @@ pub fn sign_skill_with_options(
         signature: signature_b64,
         signed_at: now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         expires_at,
+        schema_version,
+        previous_hash,
         domain: domain.to_string(),
         signer_kid: kid,
         file_manifest: manifest,
@@ -431,6 +468,58 @@ pub fn verify_skill_offline(
 
     VerificationResult::success(&sig.domain, discovery.developer_name.as_deref(), pin_status)
         .with_expiration_check(sig.expires_at.as_deref())
+        .with_lineage_metadata(sig.schema_version.as_deref(), sig.previous_hash.as_deref())
+}
+
+/// Errors returned by [`verify_chain`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChainError {
+    /// `current.previous_hash` is absent — the new signature doesn't claim a predecessor.
+    NoPreviousHash,
+    /// `current.previous_hash` is present but doesn't match `previous.skill_hash`.
+    Mismatch { expected: String, got: String },
+}
+
+impl std::fmt::Display for ChainError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoPreviousHash => write!(f, "current signature has no previous_hash field"),
+            Self::Mismatch { expected, got } => write!(
+                f,
+                "previous_hash mismatch: current.previous_hash = {}, previous.skill_hash = {}",
+                got, expected
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ChainError {}
+
+/// Verify that `current` is the legitimate successor of `previous` via the
+/// `previous_hash` lineage chain (v1.4 alpha.2).
+///
+/// Returns `Ok(())` when `current.previous_hash == Some(previous.skill_hash)`.
+///
+/// This is a pure-metadata check — no cryptography is re-evaluated. Both signatures
+/// must already be cryptographically verified separately via [`verify_skill_offline`]
+/// for the chain check to be meaningful.
+///
+/// Use this to defend against rug-pull attacks where an attacker substitutes a
+/// schema/skill out-of-band: a legitimate update declares the prior version's hash;
+/// an unauthorized substitution either omits `previous_hash` or points at a hash
+/// the verifier hasn't accepted as a valid ancestor.
+pub fn verify_chain(current: &SkillSignature, previous: &SkillSignature) -> Result<(), ChainError> {
+    let Some(claimed) = current.previous_hash.as_deref() else {
+        return Err(ChainError::NoPreviousHash);
+    };
+    if claimed == previous.skill_hash {
+        Ok(())
+    } else {
+        Err(ChainError::Mismatch {
+            expected: previous.skill_hash.clone(),
+            got: claimed.to_string(),
+        })
+    }
 }
 
 /// Verify a skill folder offline with an additional DNS TXT cross-check (v1.4).
@@ -1161,5 +1250,142 @@ mod tests {
             .warnings
             .iter()
             .any(|w| w == "signature_expires_at_unparseable"));
+    }
+
+    // ── v1.4 alpha.2: schema_version + previous_hash lineage tests ──
+
+    #[test]
+    fn test_sign_with_schema_version_writes_field() {
+        let dir = tempdir().unwrap();
+        make_skill_dir(dir.path(), &[("SKILL.md", b"---\nname: ver\n---\n")]);
+        let kp = generate_key_pair().unwrap();
+        let opts = SignOptions::new().with_schema_version("2.1.0");
+        let sig =
+            sign_skill_with_options(dir.path(), &kp.private_key_pem, "example.com", opts).unwrap();
+        assert_eq!(sig.schema_version.as_deref(), Some("2.1.0"));
+        assert_eq!(sig.schemapin_version, "1.4");
+        let on_disk = load_signature(dir.path()).unwrap();
+        assert_eq!(on_disk.schema_version.as_deref(), Some("2.1.0"));
+    }
+
+    #[test]
+    fn test_sign_without_schema_version_omits_field() {
+        let dir = tempdir().unwrap();
+        make_skill_dir(dir.path(), &[("SKILL.md", b"---\nname: noversion\n---\n")]);
+        let kp = generate_key_pair().unwrap();
+        let sig = sign_skill(dir.path(), &kp.private_key_pem, "example.com", None, None).unwrap();
+        assert!(sig.schema_version.is_none());
+        let raw = fs::read_to_string(dir.path().join(".schemapin.sig")).unwrap();
+        assert!(
+            !raw.contains("schema_version"),
+            "JSON should omit schema_version"
+        );
+        assert!(
+            !raw.contains("previous_hash"),
+            "JSON should omit previous_hash"
+        );
+    }
+
+    #[test]
+    fn test_sign_with_previous_hash_writes_field() {
+        let dir = tempdir().unwrap();
+        make_skill_dir(dir.path(), &[("SKILL.md", b"---\nname: chained\n---\n")]);
+        let kp = generate_key_pair().unwrap();
+        let opts = SignOptions::new().with_previous_hash("sha256:abcdef");
+        let sig =
+            sign_skill_with_options(dir.path(), &kp.private_key_pem, "example.com", opts).unwrap();
+        assert_eq!(sig.previous_hash.as_deref(), Some("sha256:abcdef"));
+        assert_eq!(sig.schemapin_version, "1.4");
+    }
+
+    #[test]
+    fn test_verify_chain_matches() {
+        let dir1 = tempdir().unwrap();
+        make_skill_dir(dir1.path(), &[("SKILL.md", b"---\nname: v1\n---\n")]);
+        let kp = generate_key_pair().unwrap();
+        let v1 = sign_skill(dir1.path(), &kp.private_key_pem, "example.com", None, None).unwrap();
+
+        let dir2 = tempdir().unwrap();
+        make_skill_dir(dir2.path(), &[("SKILL.md", b"---\nname: v2\n---\n")]);
+        let opts = SignOptions::new().with_previous_hash(&v1.skill_hash);
+        let v2 =
+            sign_skill_with_options(dir2.path(), &kp.private_key_pem, "example.com", opts).unwrap();
+
+        verify_chain(&v2, &v1).unwrap();
+    }
+
+    #[test]
+    fn test_verify_chain_no_previous_hash_errors() {
+        let dir1 = tempdir().unwrap();
+        let dir2 = tempdir().unwrap();
+        make_skill_dir(dir1.path(), &[("SKILL.md", b"---\nname: v1\n---\n")]);
+        make_skill_dir(dir2.path(), &[("SKILL.md", b"---\nname: v2\n---\n")]);
+        let kp = generate_key_pair().unwrap();
+        let v1 = sign_skill(dir1.path(), &kp.private_key_pem, "example.com", None, None).unwrap();
+        let v2 = sign_skill(dir2.path(), &kp.private_key_pem, "example.com", None, None).unwrap();
+
+        // v2 has no previous_hash → chain check rejects
+        assert_eq!(verify_chain(&v2, &v1), Err(ChainError::NoPreviousHash));
+    }
+
+    #[test]
+    fn test_verify_chain_mismatch_errors() {
+        let dir1 = tempdir().unwrap();
+        let dir2 = tempdir().unwrap();
+        make_skill_dir(dir1.path(), &[("SKILL.md", b"---\nname: v1\n---\n")]);
+        make_skill_dir(dir2.path(), &[("SKILL.md", b"---\nname: v2\n---\n")]);
+        let kp = generate_key_pair().unwrap();
+        let v1 = sign_skill(dir1.path(), &kp.private_key_pem, "example.com", None, None).unwrap();
+        let opts = SignOptions::new().with_previous_hash("sha256:not-the-real-prior-hash");
+        let v2 =
+            sign_skill_with_options(dir2.path(), &kp.private_key_pem, "example.com", opts).unwrap();
+
+        match verify_chain(&v2, &v1).unwrap_err() {
+            ChainError::Mismatch { expected, got } => {
+                assert_eq!(expected, v1.skill_hash);
+                assert_eq!(got, "sha256:not-the-real-prior-hash");
+            }
+            other => panic!("unexpected error: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_verify_skill_offline_surfaces_lineage_metadata() {
+        let dir = tempdir().unwrap();
+        make_skill_dir(dir.path(), &[("SKILL.md", b"---\nname: surfaced\n---\n")]);
+        let kp = generate_key_pair().unwrap();
+        let opts = SignOptions::new()
+            .with_schema_version("3.2.1")
+            .with_previous_hash("sha256:deadbeef");
+        sign_skill_with_options(dir.path(), &kp.private_key_pem, "example.com", opts).unwrap();
+
+        let discovery = build_well_known_response(&kp.public_key_pem, Some("Dev"), vec![], "1.4");
+        let result =
+            verify_skill_offline(dir.path(), &discovery, None, None, None, Some("surfaced"));
+        assert!(result.valid);
+        assert_eq!(result.schema_version.as_deref(), Some("3.2.1"));
+        assert_eq!(result.previous_hash.as_deref(), Some("sha256:deadbeef"));
+    }
+
+    #[test]
+    fn test_combined_v1_4_fields_all_round_trip() {
+        let dir = tempdir().unwrap();
+        make_skill_dir(dir.path(), &[("SKILL.md", b"---\nname: combo\n---\n")]);
+        let kp = generate_key_pair().unwrap();
+        let opts = SignOptions::new()
+            .with_expires_in(chrono::Duration::days(180))
+            .with_schema_version("1.0.0")
+            .with_previous_hash("sha256:cafebabe");
+        let sig =
+            sign_skill_with_options(dir.path(), &kp.private_key_pem, "example.com", opts).unwrap();
+        assert_eq!(sig.schemapin_version, "1.4");
+        assert!(sig.expires_at.is_some());
+        assert_eq!(sig.schema_version.as_deref(), Some("1.0.0"));
+        assert_eq!(sig.previous_hash.as_deref(), Some("sha256:cafebabe"));
+
+        let on_disk = load_signature(dir.path()).unwrap();
+        assert_eq!(on_disk.expires_at, sig.expires_at);
+        assert_eq!(on_disk.schema_version, sig.schema_version);
+        assert_eq!(on_disk.previous_hash, sig.previous_hash);
     }
 }

--- a/rust/src/verification.rs
+++ b/rust/src/verification.rs
@@ -35,6 +35,15 @@ pub struct VerificationResult {
     /// Mirrors the `expires_at` from the signature when present.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<String>,
+    /// Mirrors the `schema_version` from the signature when present (v1.4 alpha.2).
+    /// Caller-supplied semver string identifying *this* version of the artifact.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema_version: Option<String>,
+    /// Mirrors the `previous_hash` from the signature when present (v1.4 alpha.2).
+    /// `sha256:<hex>` of the prior signed version's `skill_hash`. Pair with
+    /// [`crate::skill::verify_chain`] to confirm lineage.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_hash: Option<String>,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -64,6 +73,8 @@ impl VerificationResult {
             warnings: vec![],
             expired: false,
             expires_at: None,
+            schema_version: None,
+            previous_hash: None,
         }
     }
 
@@ -78,7 +89,22 @@ impl VerificationResult {
             warnings: vec![],
             expired: false,
             expires_at: None,
+            schema_version: None,
+            previous_hash: None,
         }
+    }
+
+    /// Copy `schema_version` and `previous_hash` from the signature onto the result.
+    /// No semantic enforcement — these are informational fields callers use for
+    /// version policy and chain verification (see [`crate::skill::verify_chain`]).
+    pub fn with_lineage_metadata(
+        mut self,
+        schema_version: Option<&str>,
+        previous_hash: Option<&str>,
+    ) -> Self {
+        self.schema_version = schema_version.map(str::to_string);
+        self.previous_hash = previous_hash.map(str::to_string);
+        self
     }
 
     /// Apply a signature `expires_at` check to a successful result.


### PR DESCRIPTION
## Summary

Implements **roadmap item #2** — schema version binding (\`schema_version\` + \`previous_hash\` lineage chain) — across **Rust, Python, JavaScript, and Go** in a single PR. Two additive optional fields on \`.schemapin.sig\`, plus a new chain-verification helper in every language. Defends against rug-pull substitutions where an attacker swaps a tampered schema/skill under the same name as a previously trusted version.

## Wire format additions

Two new optional fields on \`.schemapin.sig\` (and on schema signatures by extension):

| Field | Type | Description |
|-------|------|-------------|
| \`schema_version\` | string | Caller-supplied semver string identifying *this* version of the artifact. Opaque to SchemaPin (treated as a tag). |
| \`previous_hash\` | string | \`sha256:<hex>\` of the *prior* signed version's \`skill_hash\`. Forms a hash chain across successive signatures. |

Either field bumps \`schemapin_version\` to \`\"1.4\"\`. Documents without either field remain \`\"1.3\"\`. v1.3 verifiers ignore both.

## Per-language API additions

| Language | Sign-time | Verify-time |
|----------|-----------|-------------|
| **Rust** | \`SignOptions::new().with_schema_version(\"2.1.0\").with_previous_hash(&v1.skill_hash)\` | \`schemapin::skill::verify_chain(&v2, &v1) -> Result<(), ChainError>\` |
| **Python** | \`SignOptions(schema_version=\"2.1.0\", previous_hash=v1[\"skill_hash\"])\` | \`schemapin.skill.verify_chain(v2, v1)\` raises \`ChainError\` |
| **JavaScript** | \`signSkillWithOptions(dir, key, domain, { schemaVersion, previousHash })\` | \`verifyChain(v2, v1)\` throws \`ChainError\` (with \`.kind\`) |
| **Go** | \`skill.SignOptions{ SchemaVersion: \"2.1.0\", PreviousHash: v1.SkillHash }\` | \`skill.VerifyChain(v2, v1)\` returns \`*ChainError\` |

\`VerificationResult\` (and equivalents) gains \`schema_version\` and \`previous_hash\` fields, mirrored from the signature when present. **No automatic enforcement** — chain verification is opt-in via \`verify_chain\`.

\`ChainError\` (per-language equivalent) distinguishes:
- \`NoPreviousHash\` / \`no_previous_hash\` — current sig lacks the field
- \`Mismatch\` / \`mismatch\` — both present but unequal (carries expected + observed values)

## Spec + docs

- **\`TECHNICAL_SPECIFICATION.md\` § 18** — Schema Version Binding (wire format, informational verifier semantics, opt-in chain verification, operational pattern with per-tool \`latest_known_hash\`, backward compatibility).
- **\`docs/schema-version-binding.md\`** (new) — operational guide with sign + verify_chain examples in all four languages, rotation pattern, why this defends against rug pulls, backward-compat matrix.
- \`docs/index.md\`, \`README.md\`, \`SKILL.md\`, \`context7.json\` updated to surface the new feature.
- \`ROADMAP.md\`: item #2 marked **Shipped (alpha.2, all 4 langs)**.
- \`CHANGELOG.md\`: new \`1.4.0-alpha.2\` entry above the alpha.1 block.

## Versions

All four implementations bumped to \`1.4.0-alpha.2\` (\`1.4.0a2\` in Python per PEP 440).

## QA

| Check | Result |
|-------|--------|
| Rust: \`cargo test -j2 --all-features\` | **117 passed** (was 109: +8 new) |
| Rust: \`cargo build\` no-default / default / \`--features dns\` / \`--features fetch\` / \`--all-features\` | all pass |
| Rust: \`cargo clippy --all-features -j2 -- -D warnings\` | clean |
| Rust: \`cargo fmt --check\` | clean |
| Python: \`pytest python/tests/\` | **182 passed** (was 174: +8 in new \`TestSchemaVersionBinding\` class) |
| JavaScript: \`npm test\` | 161 tests across 33 suites; new \`Schema version binding\` describe with 8 subtests passes |
| Go: \`go test ./...\` | all packages pass; new \`pkg/skill/lineage_test.go\` with 8 tests |
| Go: \`go vet ./...\` | clean |
| Go: \`gofmt\` on touched files | clean |
| \`python3 -m json.tool context7.json\` | clean |
| Markdown link scan | clean |

## Backward compatibility

| Verifier ↓ / Signer → | v1.3 sig | v1.4 sig (no lineage) | v1.4 sig (with lineage) |
|-----------------------|----------|------------------------|--------------------------|
| **v1.3 verifier** | works | works (fields ignored) | works (fields ignored) |
| **v1.4 verifier** | works (no lineage) | works (no lineage) | lineage surfaced; chain enforcement opt-in |

- v1.3 verifiers ignore both new fields.
- v1.4 signatures without lineage opts keep \`schemapin_version: \"1.3\"\`.
- The chain-verification helper is opt-in.

## Roadmap impact

- **Item #2 — Schema version binding: Shipped (alpha.2, all 4 langs)**
- Remaining v1.4 work for stable: items 4 (canonicalization id), 5 (A2A context, blocked on AgentPin v0.3.0 \`AllowedDomains\`), 6 (A2A trust bundles), 7 (scan-aware signatures, depends on ClawHavoc integration), 8 (cross-agent schema cache).

## Test plan

- [x] All four language test suites green
- [x] Clippy + fmt + vet clean
- [x] context7.json valid; markdown links resolve
- [ ] Cross-language interop test (sign in Rust, verify chain in Python; sign in Go, verify chain in JS) — deferred to a follow-up