### PR TITLE
v1.4-alpha.3: canonicalization id + A2A verification context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,78 @@ All notable changes to the SchemaPin project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0-alpha.3] - 2026-05-16
+
+### Added
+
+#### Canonicalization Algorithm Identifier — All Four Languages
+
+Optional `canonicalization` field on `.schemapin.sig` (and the
+`canonicalization` parameter on `verify_schema_offline`-family functions)
+naming the algorithm used to produce the signing input. Forward-compatibility
+hook so a future v2.x can swap canonicalization without breaking v1.x
+signatures.
+
+- **Wire format**: `"canonicalization": "schemapin-v1"` — optional, omitted when
+  absent. Absence is equivalent to `"schemapin-v1"` (v1.3 backward
+  compatibility).
+- **Verifier semantics**: absent / `"schemapin-v1"` accepted; any other value
+  is a **hard failure** surfacing as the new `CANONICALIZATION_UNSUPPORTED` /
+  `canonicalization_unsupported` error code.
+- **Sign-time API**: `SignOptions.canonicalization` (or `with_canonicalization`
+  builder in Rust). Default omits the field on the wire so v1.3 signatures
+  stay byte-identical.
+- **Verifier API**:
+  - Rust: `verify_schema_offline_with_canonicalization(...)` (thin extension
+    of `verify_schema_offline`).
+  - JavaScript: optional `canonicalization` parameter on `verifySchemaOffline`.
+  - Python: optional `canonicalization` keyword arg on `verify_schema_offline`.
+  - Go: `VerifySchemaOfflineWithCanonicalization(...)` (paired with the
+    backward-compatible `VerifySchemaOffline` wrapper).
+
+#### A2A Verification Context — All Four Languages
+
+`A2aVerificationContext` and `verify_schema_for_a2a` extend the standard 7-step
+verification flow with an A2A (Agent-to-Agent) scope check. Closes the
+cross-protocol loop with AgentPin v0.3's `AllowedDomains` typed wrapper
+(AgentPin technical spec §4.11).
+
+- **`A2aVerificationContext`**: `caller_agent_id` (URN-style), `delegation_depth`,
+  `originating_domain`, `trusted_domains`. The `trusted_domains` field uses the
+  AgentPin convention — **an empty list means *unrestricted*** (all domains
+  trusted), not "deny-all".
+- **`verify_schema_for_a2a(...)`**: wraps `verify_schema_offline` with two
+  extra checks:
+  1. **Delegation depth cap** — reject when `delegation_depth > 3`. Mirrors
+     AgentPin's `max_delegation_depth` cap; kept in lockstep at constant
+     `A2A_MAX_DELEGATION_DEPTH`.
+  2. **Scope check** — when `trusted_domains` is non-empty, reject when the
+     provider domain is not allowed by it (wildcard-aware via `*.suffix`
+     matching from AgentPin spec §5.5).
+  - Both surface as the new `A2A_SCOPE_VIOLATION` / `a2a_scope_violation`
+    error code.
+- **`AllowedDomains` helpers** (`is_unrestricted` / `allows` / `intersect`)
+  are exposed locally in each SDK rather than via a hard dependency on the
+  AgentPin SDK. The wire and in-memory shapes are identical to AgentPin's, so
+  callers that link both packages can pass `agentpin.AllowedDomains.intersect(...)`
+  results into `trusted_domains` verbatim.
+- **Intersection edge case** explicitly documented (AgentPin spec §4.11.4):
+  two non-empty disjoint allow-lists intersect to `[]`, which the convention
+  treats as *unrestricted*. The `verify_schema_for_a2a` implementation uses
+  `allows(trusted_domains, domain)` directly, NOT
+  `allows(intersect(trusted, [domain]))`, so the scope check correctly fires
+  when the caller is restricted to a disjoint allow-list.
+
+### Notes
+
+- All v1.4 alpha.3 additions are **additive optional fields / parameters**.
+  v1.3 verifiers and existing v1.4 alpha.1/alpha.2 signatures are unaffected.
+- This is items 4 + 5 of the v1.4 roadmap. Items 6–8 (A2A trust bundle
+  distribution, scan-aware signatures, cross-agent schema cache) follow in
+  `1.4.0-alpha.4` and `1.4.0` final per the scope doc at
+  `docs/superpowers/specs/2026-05-15-v1.4-remaining-items.md` (local only).
+- All four SDKs at `1.4.0-alpha.3` / `1.4.0a3` (Python per PEP 440).
+
 ## [1.4.0-alpha.2] - 2026-05-01
 
 ### Added

--- a/TECHNICAL_SPECIFICATION.md
+++ b/TECHNICAL_SPECIFICATION.md
@@ -1,8 +1,19 @@
 # SchemaPin: A Technical Specification
 
-Version 1.2
+Version 1.4 (alpha.3)
 
 Status: Draft
+
+> **What's new in v1.4 alpha.3 (2026-05-16, additive, wire-compatible
+> with v1.3 / v1.4 alpha.1 / v1.4 alpha.2):**
+> §19 introduces an optional `canonicalization` field on `.schemapin.sig`
+> for forward-compatibility with future canonicalization algorithms;
+> unknown values are a hard failure (`CANONICALIZATION_UNSUPPORTED`).
+> §20 introduces `A2aVerificationContext` and `verify_schema_for_a2a` for
+> A2A-aware verification, interoperating with AgentPin v0.3's
+> `AllowedDomains` typed wrapper. The scope check uses the empty-list
+> means *unrestricted* convention (AgentPin spec §4.11) and enforces a
+> delegation-depth cap matching AgentPin's `max_delegation_depth`.
 
 ### **1. Introduction**
 
@@ -485,3 +496,95 @@ This pairs cleanly with `schema_version`: the verifier can also enforce monotoni
 - v1.3 verifiers ignore both fields; signatures continue to verify.
 - v1.4 signatures without `schema_version` or `previous_hash` behave identically to v1.3 signatures.
 - The chain-verification helper is opt-in: callers who don't track lineage are unaffected.
+
+### **19. Canonicalization Algorithm Identifier (v1.4)**
+
+#### **19.1. Purpose**
+
+The canonicalization rules of §4 are fixed across all v1.x signatures. To leave a forward-compatibility hook for a future v2.x canonicalization (e.g. RFC 8785 / JCS) without breaking existing v1.x signatures, v1.4 introduces an optional `canonicalization` field on `.schemapin.sig` documents (and a matching parameter on the verifier APIs).
+
+The current and only supported value is `"schemapin-v1"` — the algorithm specified in §4. Future spec versions MAY introduce new identifiers; verifiers MUST reject any unrecognised identifier rather than silently fall back, so signers cannot trick a v1.x verifier into trusting a v2.x signing input.
+
+#### **19.2. Wire Format**
+
+```json
+{
+  "schemapin_version": "1.4",
+  "canonicalization": "schemapin-v1",
+  ...
+}
+```
+
+The field is OPTIONAL. Absence is wire-equivalent to the implicit `"schemapin-v1"` default — signers who do not need to declare the algorithm SHOULD omit the field to keep v1.3-byte-identical wire output.
+
+#### **19.3. Verifier Semantics**
+
+Given a signature with `canonicalization == V`:
+
+| Value of `V` | Verifier action |
+|---|---|
+| Absent (field missing) | Use `schemapin-v1` (the algorithm in §4). |
+| `"schemapin-v1"` | Use `schemapin-v1`. |
+| Anything else | **Hard failure** — surface as `CANONICALIZATION_UNSUPPORTED`. |
+
+This check MUST execute before any cryptographic work (signature verification, public-key loading) so a misconfigured signer cannot induce timing-dependent failures.
+
+#### **19.4. Backward Compatibility**
+
+- v1.3 verifiers ignore unknown fields; v1.4 signatures with `canonicalization: "schemapin-v1"` continue to verify under v1.3.
+- v1.4 signatures without `canonicalization` behave identically to v1.3 signatures.
+
+### **20. A2A Verification Context (v1.4)**
+
+#### **20.1. Purpose**
+
+When tool schemas cross an A2A (Agent-to-Agent) trust boundary, verifiers need to scope verification to the intersection of *caller-trusted* domains and the *tool provider's* domain. SchemaPin v1.4 introduces `A2aVerificationContext` and `verify_schema_for_a2a` for this purpose. The semantics interoperate with AgentPin v0.3's `AllowedDomains` typed wrapper (AgentPin technical specification §4.11) so a SchemaPin verifier can directly consume the allow-list a caller's AgentPin credential carries.
+
+#### **20.2. `A2aVerificationContext`**
+
+```text
+A2aVerificationContext {
+  caller_agent_id:    String      // URN-style, matching AgentPin; informational
+  delegation_depth:   u8          // 0 = direct caller
+  originating_domain: String      // informational
+  trusted_domains:    [String]    // see §20.3 convention
+}
+```
+
+`caller_agent_id` and `originating_domain` are informational — verifiers do not validate them or use them in the scope check. Downstream policy engines (e.g. Symbiont) MAY correlate verification results with these fields for audit purposes.
+
+#### **20.3. AllowedDomains Convention**
+
+The `trusted_domains` list uses the same convention as AgentPin v0.3:
+
+> **An empty `trusted_domains` list means *unrestricted*** — all provider domains are trusted. This is the opposite of the naïve set-theoretic interpretation but it matches the existing behaviour where an *omitted* allow-list permitted all domains.
+
+A non-empty list restricts the verifier to provider domains that match an entry. Pattern matching follows the AgentPin §5.5 wildcard rule: a leading `*.` matches any subdomain (e.g. `*.client.com` matches `api.client.com` but NOT `client.com` itself).
+
+#### **20.4. Verification Algorithm**
+
+Given a context `C` and a normal verification request for provider domain `D`:
+
+1. **Delegation-depth cap.** If `C.delegation_depth > 3`, fail with `A2A_SCOPE_VIOLATION`. The cap of 3 mirrors AgentPin's `max_delegation_depth` (AgentPin spec §4.3) and is exposed as the constant `A2A_MAX_DELEGATION_DEPTH`. Both specs MUST move this cap in lockstep.
+2. **Standard verification.** Run the 7-step verification flow from §7 (including the §19 canonicalization check when applicable). If it fails, return that result unchanged — A2A scope is NOT a remedy for a failed cryptographic verification.
+3. **Scope check.** When `C.trusted_domains` is non-empty, test whether `D` is allowed by the list under §20.3 semantics. If not, fail with `A2A_SCOPE_VIOLATION`. When `C.trusted_domains` is empty (unrestricted), this step is a no-op.
+
+The scope check MUST use the `allows(trusted_domains, D)` primitive directly, NOT `allows(intersect(trusted_domains, [D]))`. The intersection helper documented in §20.5 has an edge case where two non-empty disjoint allow-lists intersect to `[]`, which the convention treats as "unrestricted" — using `intersect` here would silently bypass the scope check.
+
+#### **20.5. AllowedDomains Helpers**
+
+Each SDK MUST expose helpers matching the AgentPin v0.3 `AllowedDomains` API exactly:
+
+| Operation | Behaviour |
+|---|---|
+| `is_unrestricted(list)` | `true` when `list` is empty. |
+| `allows(list, domain)` | `true` when `list` is empty OR `domain` matches any entry (with `*.` wildcard expansion). |
+| `intersect(lhs, rhs)` | `lhs ∩ rhs`, with two `unrestricted` short-circuits: `unrestricted ∩ X = X`, `X ∩ unrestricted = X`. Two non-empty disjoint inputs intersect to `[]` which, under the convention, then *also* means "unrestricted" — documented edge case from AgentPin spec §4.11.4. |
+
+Implementations SHOULD copy these helpers from this section rather than taking a hard dependency on the AgentPin SDK, to keep SchemaPin self-contained for tool-integrity-only deployments. When both SDKs are linked, the AgentPin helpers can be substituted directly — the wire and in-memory shapes are identical.
+
+#### **20.6. Backward Compatibility**
+
+- v1.3 verifiers do not know about A2A context — they have no `verify_schema_for_a2a` entry point. Callers integrating with v1.3 verifiers fall back to the standard `verify_schema_offline` flow without scope enforcement.
+- The `A2A_SCOPE_VIOLATION` error code is new in v1.4. Older verifiers cannot emit it.
+- All v1.4 alpha.3 additions are additive — they introduce no changes to the signature on the wire (the new error code lives only in verifier output) so v1.4 alpha.1 / alpha.2 signatures verify identically under alpha.3 verifiers.

--- a/go/internal/version/version.go
+++ b/go/internal/version/version.go
@@ -2,7 +2,7 @@
 package version
 
 // Version is set at build time via ldflags
-var Version = "1.4.0-alpha.2"
+var Version = "1.4.0-alpha.3"
 
 // GetVersion returns the current version string
 func GetVersion() string {

--- a/go/pkg/bundle/bundle.go
+++ b/go/pkg/bundle/bundle.go
@@ -12,7 +12,7 @@ import (
 // BundledDiscovery combines a domain with its well-known response.
 // Uses custom JSON marshaling for flattened format.
 type BundledDiscovery struct {
-	Domain   string
+	Domain    string
 	WellKnown discovery.WellKnownResponse
 }
 
@@ -59,9 +59,9 @@ func (b *BundledDiscovery) UnmarshalJSON(data []byte) error {
 
 // SchemaPinTrustBundle holds discovery documents and revocations for offline use.
 type SchemaPinTrustBundle struct {
-	SchemapinBundleVersion string                       `json:"schemapin_bundle_version"`
-	CreatedAt              string                       `json:"created_at"`
-	Documents              []BundledDiscovery           `json:"documents"`
+	SchemapinBundleVersion string                          `json:"schemapin_bundle_version"`
+	CreatedAt              string                          `json:"created_at"`
+	Documents              []BundledDiscovery              `json:"documents"`
 	Revocations            []revocation.RevocationDocument `json:"revocations"`
 }
 

--- a/go/pkg/revocation/revocation.go
+++ b/go/pkg/revocation/revocation.go
@@ -13,10 +13,10 @@ import (
 type RevocationReason string
 
 const (
-	ReasonKeyCompromise         RevocationReason = "key_compromise"
-	ReasonSuperseded            RevocationReason = "superseded"
-	ReasonCessationOfOperation  RevocationReason = "cessation_of_operation"
-	ReasonPrivilegeWithdrawn    RevocationReason = "privilege_withdrawn"
+	ReasonKeyCompromise        RevocationReason = "key_compromise"
+	ReasonSuperseded           RevocationReason = "superseded"
+	ReasonCessationOfOperation RevocationReason = "cessation_of_operation"
+	ReasonPrivilegeWithdrawn   RevocationReason = "privilege_withdrawn"
 )
 
 // RevokedKey represents a single revoked key entry.

--- a/go/pkg/skill/skill.go
+++ b/go/pkg/skill/skill.go
@@ -54,14 +54,18 @@ const (
 //   - PreviousHash: sha256:<hex> of the prior signed version's SkillHash,
 //     forming a hash chain. Pair with VerifyChain.
 type SkillSignature struct {
-	SchemapinVersion string            `json:"schemapin_version"`
-	SkillName        string            `json:"skill_name"`
-	SkillHash        string            `json:"skill_hash"`
-	Signature        string            `json:"signature"`
-	SignedAt         string            `json:"signed_at"`
-	ExpiresAt        string            `json:"expires_at,omitempty"`
-	SchemaVersion    string            `json:"schema_version,omitempty"`
-	PreviousHash     string            `json:"previous_hash,omitempty"`
+	SchemapinVersion string `json:"schemapin_version"`
+	SkillName        string `json:"skill_name"`
+	SkillHash        string `json:"skill_hash"`
+	Signature        string `json:"signature"`
+	SignedAt         string `json:"signed_at"`
+	ExpiresAt        string `json:"expires_at,omitempty"`
+	SchemaVersion    string `json:"schema_version,omitempty"`
+	PreviousHash     string `json:"previous_hash,omitempty"`
+	// Canonicalization (v1.4 alpha.3) names the algorithm used to produce
+	// the signing input. Absence is wire-equivalent to "schemapin-v1".
+	// Verifiers MUST reject any other value as ErrCanonicalizationUnsupported.
+	Canonicalization string            `json:"canonicalization,omitempty"`
 	Domain           string            `json:"domain"`
 	SignerKid        string            `json:"signer_kid"`
 	FileManifest     map[string]string `json:"file_manifest"`
@@ -92,6 +96,10 @@ type SignOptions struct {
 	// forming a hash chain (v1.4 alpha.2). Pair with VerifyChain at verify
 	// time. Empty omits the field.
 	PreviousHash string
+	// Canonicalization (v1.4 alpha.3) is the algorithm identifier to write
+	// into the signature. Empty omits the field on the wire (== implicit
+	// "schemapin-v1"); pass "schemapin-v1" to declare it explicitly.
+	Canonicalization string
 }
 
 // TamperedFiles holds the result of comparing two file manifests.
@@ -330,7 +338,7 @@ func SignSkillWithOptions(skillDir, privateKeyPEM, domain string, options SignOp
 	// Any v1.4 optional field bumps the version stamp; pure v1.3 sigs stay
 	// "1.3" for byte-stable backward compatibility.
 	version := schemapinVersionV13
-	if expiresAt != "" || options.SchemaVersion != "" || options.PreviousHash != "" {
+	if expiresAt != "" || options.SchemaVersion != "" || options.PreviousHash != "" || options.Canonicalization != "" {
 		version = schemapinVersionV14
 	}
 
@@ -343,6 +351,7 @@ func SignSkillWithOptions(skillDir, privateKeyPEM, domain string, options SignOp
 		ExpiresAt:        expiresAt,
 		SchemaVersion:    options.SchemaVersion,
 		PreviousHash:     options.PreviousHash,
+		Canonicalization: options.Canonicalization,
 		Domain:           domain,
 		SignerKid:        signerKid,
 		FileManifest:     manifest,
@@ -389,6 +398,16 @@ func VerifySkillOffline(
 		toolID = sig.SkillName
 		if toolID == "" {
 			toolID = filepath.Base(skillDir)
+		}
+	}
+
+	// Step 1a (v1.4 alpha.3): canonicalization algorithm check.
+	if bad := verification.CheckCanonicalization(sig.Canonicalization); bad != "" {
+		return &verification.VerificationResult{
+			Valid:        false,
+			Domain:       domain,
+			ErrorCode:    verification.ErrCanonicalizationUnsupported,
+			ErrorMessage: fmt.Sprintf("Unsupported canonicalization algorithm: %s", bad),
 		}
 	}
 

--- a/go/pkg/skill/skill_test.go
+++ b/go/pkg/skill/skill_test.go
@@ -89,7 +89,7 @@ func TestCanonicalizeSortedDeterministic(t *testing.T) {
 
 func TestCanonicalizeSkipSigFile(t *testing.T) {
 	dir := createSkillDir(t, map[string]string{
-		"main.py":       "print('hello')",
+		"main.py":        "print('hello')",
 		".schemapin.sig": `{"signature":"old"}`,
 	})
 
@@ -642,9 +642,9 @@ func TestDetectTamperedFiles(t *testing.T) {
 		"c.txt": "sha256:ccc",
 	}
 	current := map[string]string{
-		"a.txt": "sha256:aaa",       // unchanged
-		"b.txt": "sha256:modified",  // modified
-		"d.txt": "sha256:ddd",       // added
+		"a.txt": "sha256:aaa",      // unchanged
+		"b.txt": "sha256:modified", // modified
+		"d.txt": "sha256:ddd",      // added
 	}
 
 	result := DetectTamperedFiles(current, signed)
@@ -697,7 +697,7 @@ func buildTrustBundleJSON(t *testing.T, pubPEM, domain string) string {
 	t.Helper()
 	bundleData := map[string]interface{}{
 		"schemapin_bundle_version": "1.2",
-		"created_at":              "2024-01-01T00:00:00Z",
+		"created_at":               "2024-01-01T00:00:00Z",
 		"documents": []map[string]interface{}{
 			{
 				"domain":         domain,

--- a/go/pkg/verification/a2a.go
+++ b/go/pkg/verification/a2a.go
@@ -1,0 +1,152 @@
+package verification
+
+// A2A verification context for SchemaPin (v1.4 alpha.3).
+//
+// Mirrors the Rust schemapin::types::a2a module and the AgentPin v0.3
+// AllowedDomains semantics (AgentPin technical specification §4.11).
+//
+// When a SchemaPin verification crosses an A2A (Agent-to-Agent) trust
+// boundary, the verifier needs to scope the result to the intersection of
+// caller-trusted domains and the tool provider's domain. A2AVerificationContext
+// carries that scoping data; pair it with VerifySchemaForA2A.
+//
+// AllowedDomains convention
+//
+// The allow-list semantics follow AgentPin v0.3 exactly:
+//
+//	An empty TrustedDomains list means UNRESTRICTED — all domains trusted.
+//	This is the opposite of the naïve set-theoretic interpretation but
+//	matches v1.3 behaviour where an *omitted* allowed_domains field allowed
+//	all domains.
+//
+// SchemaPin re-implements these helpers locally rather than depending on
+// the agentpin Go module — keeping SchemaPin self-contained and avoiding a
+// circular trust-stack dependency. Callers who *do* depend on both modules
+// can pass the result of agentpin's intersection helper directly into
+// TrustedDomains — the wire and in-memory shapes are identical.
+
+// A2AMaxDelegationDepth is the maximum A2A delegation depth allowed by
+// this verifier (v1.4 alpha.3).
+//
+// Mirrors the AgentPin max_delegation_depth cap (AgentPin spec §4.3).
+// Bumping this on the SchemaPin side without a matching bump on AgentPin
+// would let SchemaPin accept chains AgentPin would reject — keep in lockstep.
+const A2AMaxDelegationDepth uint8 = 3
+
+// A2AVerificationContext scopes a schema verification to an A2A interaction.
+//
+// Pair with VerifySchemaForA2A to run the standard 7-step verification flow
+// with the additional A2A scope check.
+type A2AVerificationContext struct {
+	// CallerAgentID is the caller's agent identity (URN-style, matching
+	// AgentPin). Informational only — SchemaPin does not validate the URN
+	// shape.
+	CallerAgentID string
+
+	// DelegationDepth is the depth in the A2A delegation chain. 0 = direct
+	// caller. Verifiers SHOULD reject DelegationDepth > A2AMaxDelegationDepth.
+	DelegationDepth uint8
+
+	// OriginatingDomain is the originating domain of the A2A request.
+	// Informational; the scope check uses TrustedDomains vs. provider domain.
+	OriginatingDomain string
+
+	// TrustedDomains is the caller-trusted domain allow-list. Uses the
+	// AgentPin convention: an empty slice means UNRESTRICTED (all domains
+	// trusted), not "deny-all".
+	TrustedDomains []string
+}
+
+// NewUnrestrictedA2AContext constructs a context that places no restriction
+// on which provider domains may be verified through.
+func NewUnrestrictedA2AContext(callerAgentID string) *A2AVerificationContext {
+	return &A2AVerificationContext{
+		CallerAgentID:   callerAgentID,
+		DelegationDepth: 0,
+	}
+}
+
+// AllowedDomains helpers
+//
+// Spec source of truth: AgentPin technical specification §4.11. This file
+// re-implements the helpers locally rather than linking the agentpin Go
+// module. Update both projects in lockstep if the convention ever changes.
+
+// A2AIsUnrestricted returns true when list is empty (no restriction).
+func A2AIsUnrestricted(list []string) bool {
+	return len(list) == 0
+}
+
+// A2AAllows returns true when domain is permitted under list.
+//
+// An empty list allows everything. A non-empty list allows domain when it
+// exactly matches an entry OR matches one of the entry's wildcard
+// patterns. Pattern matching follows AgentPin spec §5.5: a leading "*."
+// matches any subdomain (e.g. "*.client.com" matches "api.client.com" but
+// NOT "client.com" itself).
+func A2AAllows(list []string, domain string) bool {
+	if A2AIsUnrestricted(list) {
+		return true
+	}
+	for _, p := range list {
+		if patternMatches(p, domain) {
+			return true
+		}
+	}
+	return false
+}
+
+// A2AIntersect returns the intersection of two allow-lists, honouring the
+// empty-is-unrestricted convention.
+//
+//   - unrestricted ∩ X = X
+//   - X ∩ unrestricted = X
+//   - Otherwise: literal set intersection (string equality; no wildcard
+//     expansion), preserving the order of lhs.
+//
+// An intersection that yields an empty slice from two non-empty inputs is
+// *re-interpreted as unrestricted* under the same convention — see AgentPin
+// spec §4.11.4. Callers needing to distinguish "intentionally restricted to
+// nothing" from "no restriction" must track that outside the slice.
+func A2AIntersect(lhs, rhs []string) []string {
+	if A2AIsUnrestricted(lhs) {
+		out := make([]string, len(rhs))
+		copy(out, rhs)
+		return out
+	}
+	if A2AIsUnrestricted(rhs) {
+		out := make([]string, len(lhs))
+		copy(out, lhs)
+		return out
+	}
+	rhsSet := make(map[string]struct{}, len(rhs))
+	for _, d := range rhs {
+		rhsSet[d] = struct{}{}
+	}
+	out := make([]string, 0)
+	for _, d := range lhs {
+		if _, ok := rhsSet[d]; ok {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// patternMatches is a wildcard-aware domain pattern matcher.
+//
+// "*.example.com" matches "api.example.com" and "a.b.example.com" but NOT
+// "example.com" itself. Anything without a leading "*." is a literal
+// equality check.
+func patternMatches(pattern, domain string) bool {
+	if len(pattern) > 2 && pattern[0] == '*' && pattern[1] == '.' {
+		suffix := pattern[2:]
+		if len(domain) <= len(suffix) {
+			return false
+		}
+		if domain[len(domain)-len(suffix):] != suffix {
+			return false
+		}
+		return domain[len(domain)-len(suffix)-1] == '.'
+	}
+	return pattern == domain
+}

--- a/go/pkg/verification/a2a_test.go
+++ b/go/pkg/verification/a2a_test.go
@@ -1,0 +1,291 @@
+package verification
+
+import (
+	"testing"
+
+	"github.com/ThirdKeyAi/schemapin/go/pkg/core"
+	"github.com/ThirdKeyAi/schemapin/go/pkg/crypto"
+	"github.com/ThirdKeyAi/schemapin/go/pkg/discovery"
+)
+
+// ──────────────────────────────────────────────────────────────────────
+// AllowedDomains helpers — AgentPin v0.3 §4.11 semantics
+// ──────────────────────────────────────────────────────────────────────
+
+func TestA2AIsUnrestricted(t *testing.T) {
+	if !A2AIsUnrestricted(nil) {
+		t.Error("nil should be unrestricted")
+	}
+	if !A2AIsUnrestricted([]string{}) {
+		t.Error("empty slice should be unrestricted")
+	}
+	if A2AIsUnrestricted([]string{"a.com"}) {
+		t.Error("non-empty slice should not be unrestricted")
+	}
+}
+
+func TestA2AAllowsUnrestricted(t *testing.T) {
+	if !A2AAllows(nil, "literally-anything") {
+		t.Error("nil list should allow anything")
+	}
+}
+
+func TestA2AAllowsRestricted(t *testing.T) {
+	ad := []string{"api.client.com", "*.partner.com"}
+	cases := map[string]bool{
+		"api.client.com":         true,
+		"tools.partner.com":      true,
+		"deep.tools.partner.com": true,
+		"partner.com":            false, // *.partner.com excludes bare
+		"evil.example.com":       false,
+	}
+	for domain, want := range cases {
+		got := A2AAllows(ad, domain)
+		if got != want {
+			t.Errorf("A2AAllows(%v, %q) = %v, want %v", ad, domain, got, want)
+		}
+	}
+}
+
+func TestA2AIntersectWithUnrestrictedReturnsOther(t *testing.T) {
+	restricted := []string{"a.com", "b.com"}
+	got := A2AIntersect(nil, restricted)
+	if len(got) != 2 || got[0] != "a.com" || got[1] != "b.com" {
+		t.Errorf("unrestricted ∩ X should equal X, got %v", got)
+	}
+	got = A2AIntersect(restricted, nil)
+	if len(got) != 2 || got[0] != "a.com" || got[1] != "b.com" {
+		t.Errorf("X ∩ unrestricted should equal X, got %v", got)
+	}
+}
+
+func TestA2AIntersectOverlap(t *testing.T) {
+	got := A2AIntersect([]string{"a.com", "b.com", "c.com"}, []string{"b.com", "c.com", "d.com"})
+	want := []string{"b.com", "c.com"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("expected %v, got %v", want, got)
+	}
+}
+
+func TestA2AIntersectEmptyOverlapIsUnrestricted(t *testing.T) {
+	got := A2AIntersect([]string{"a.com"}, []string{"b.com"})
+	if !A2AIsUnrestricted(got) {
+		t.Errorf("disjoint non-empty intersection should be re-interpreted as unrestricted, got %v", got)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Canonicalization id
+// ──────────────────────────────────────────────────────────────────────
+
+func TestCheckCanonicalizationAbsent(t *testing.T) {
+	if got := CheckCanonicalization(""); got != "" {
+		t.Errorf("empty should be supported, got %q", got)
+	}
+}
+
+func TestCheckCanonicalizationV1(t *testing.T) {
+	if got := CheckCanonicalization(CanonicalizationV1); got != "" {
+		t.Errorf("v1 should be supported, got %q", got)
+	}
+}
+
+func TestCheckCanonicalizationUnknown(t *testing.T) {
+	if got := CheckCanonicalization("schemapin-v999"); got != "schemapin-v999" {
+		t.Errorf("unknown should return offending value, got %q", got)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// VerifySchemaForA2A — signed fixture helper
+// ──────────────────────────────────────────────────────────────────────
+
+type signedFixture struct {
+	schema map[string]interface{}
+	sig    string
+	disc   *discovery.WellKnownResponse
+}
+
+func setupSignedSchema(t *testing.T) *signedFixture {
+	t.Helper()
+	kp, err := crypto.NewKeyManager().GenerateKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubPEM, err := crypto.NewKeyManager().ExportPublicKeyPEM(&kp.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := map[string]interface{}{
+		"name":        "calculate_sum",
+		"description": "Calculates the sum of two numbers",
+		"parameters":  map[string]interface{}{"a": "integer", "b": "integer"},
+	}
+	c := core.NewSchemaPinCore()
+	schemaHash, err := c.CanonicalizeAndHash(schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig, err := crypto.NewSignatureManager().SignHash(schemaHash, kp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &signedFixture{
+		schema: schema,
+		sig:    sig,
+		disc: &discovery.WellKnownResponse{
+			SchemaVersion: "1.2",
+			DeveloperName: "Test Developer",
+			PublicKeyPEM:  pubPEM,
+		},
+	}
+}
+
+func ctxFor(trusted []string, depth uint8) *A2AVerificationContext {
+	return &A2AVerificationContext{
+		CallerAgentID:     "urn:agentpin:caller.com:test",
+		DelegationDepth:   depth,
+		OriginatingDomain: "caller.com",
+		TrustedDomains:    trusted,
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// verifySchemaOfflineWithCanonicalization
+// ──────────────────────────────────────────────────────────────────────
+
+func TestVerifySchemaOfflineCanonicalizationAbsent(t *testing.T) {
+	f := setupSignedSchema(t)
+	result := VerifySchemaOfflineWithCanonicalization(
+		f.schema, f.sig, "example.com", "calculate_sum",
+		f.disc, nil, NewKeyPinStore(), "",
+	)
+	if !result.Valid {
+		t.Fatalf("expected valid, got %+v", result)
+	}
+}
+
+func TestVerifySchemaOfflineCanonicalizationV1(t *testing.T) {
+	f := setupSignedSchema(t)
+	result := VerifySchemaOfflineWithCanonicalization(
+		f.schema, f.sig, "example.com", "calculate_sum",
+		f.disc, nil, NewKeyPinStore(), CanonicalizationV1,
+	)
+	if !result.Valid {
+		t.Fatalf("expected valid, got %+v", result)
+	}
+}
+
+func TestVerifySchemaOfflineCanonicalizationUnknown(t *testing.T) {
+	f := setupSignedSchema(t)
+	result := VerifySchemaOfflineWithCanonicalization(
+		f.schema, f.sig, "example.com", "calculate_sum",
+		f.disc, nil, NewKeyPinStore(), "schemapin-v999",
+	)
+	if result.Valid {
+		t.Fatal("expected invalid")
+	}
+	if result.ErrorCode != ErrCanonicalizationUnsupported {
+		t.Errorf("expected %s, got %s", ErrCanonicalizationUnsupported, result.ErrorCode)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// VerifySchemaForA2A
+// ──────────────────────────────────────────────────────────────────────
+
+func TestVerifySchemaForA2AUnrestrictedCaller(t *testing.T) {
+	f := setupSignedSchema(t)
+	result := VerifySchemaForA2A(
+		f.schema, f.sig, "example.com", "calculate_sum",
+		f.disc, nil, NewKeyPinStore(),
+		ctxFor(nil, 0), "",
+	)
+	if !result.Valid {
+		t.Fatalf("expected valid, got %+v", result)
+	}
+}
+
+func TestVerifySchemaForA2ACallerAllowsProvider(t *testing.T) {
+	f := setupSignedSchema(t)
+	result := VerifySchemaForA2A(
+		f.schema, f.sig, "example.com", "calculate_sum",
+		f.disc, nil, NewKeyPinStore(),
+		ctxFor([]string{"example.com", "other.com"}, 1), "",
+	)
+	if !result.Valid {
+		t.Fatalf("expected valid, got %+v", result)
+	}
+}
+
+func TestVerifySchemaForA2AProviderOutsideScope(t *testing.T) {
+	f := setupSignedSchema(t)
+	result := VerifySchemaForA2A(
+		f.schema, f.sig, "example.com", "calculate_sum",
+		f.disc, nil, NewKeyPinStore(),
+		ctxFor([]string{"other.com"}, 0), "",
+	)
+	if result.Valid {
+		t.Fatal("expected invalid")
+	}
+	if result.ErrorCode != ErrA2AScopeViolation {
+		t.Errorf("expected %s, got %s", ErrA2AScopeViolation, result.ErrorCode)
+	}
+}
+
+func TestVerifySchemaForA2ADelegationDepthCap(t *testing.T) {
+	f := setupSignedSchema(t)
+	result := VerifySchemaForA2A(
+		f.schema, f.sig, "example.com", "calculate_sum",
+		f.disc, nil, NewKeyPinStore(),
+		ctxFor(nil, A2AMaxDelegationDepth+1), "",
+	)
+	if result.Valid {
+		t.Fatal("expected invalid")
+	}
+	if result.ErrorCode != ErrA2AScopeViolation {
+		t.Errorf("expected %s, got %s", ErrA2AScopeViolation, result.ErrorCode)
+	}
+}
+
+func TestVerifySchemaForA2AUnderlyingFailurePassesThrough(t *testing.T) {
+	f := setupSignedSchema(t)
+	result := VerifySchemaForA2A(
+		f.schema, "bm90LWEtdmFsaWQtc2lnbmF0dXJl", "example.com", "calculate_sum",
+		f.disc, nil, NewKeyPinStore(),
+		ctxFor(nil, 0), "",
+	)
+	if result.Valid {
+		t.Fatal("expected invalid")
+	}
+	if result.ErrorCode != ErrSignatureInvalid {
+		t.Errorf("expected %s (underlying failure), got %s", ErrSignatureInvalid, result.ErrorCode)
+	}
+}
+
+func TestVerifySchemaForA2ACanonicalizationUnknownPropagates(t *testing.T) {
+	f := setupSignedSchema(t)
+	result := VerifySchemaForA2A(
+		f.schema, f.sig, "example.com", "calculate_sum",
+		f.disc, nil, NewKeyPinStore(),
+		ctxFor(nil, 0), "schemapin-v999",
+	)
+	if result.Valid {
+		t.Fatal("expected invalid")
+	}
+	if result.ErrorCode != ErrCanonicalizationUnsupported {
+		t.Errorf("expected %s, got %s", ErrCanonicalizationUnsupported, result.ErrorCode)
+	}
+}
+
+func TestVerifySchemaForA2AWildcardCallerAllowList(t *testing.T) {
+	f := setupSignedSchema(t)
+	result := VerifySchemaForA2A(
+		f.schema, f.sig, "api.example.com", "calculate_sum",
+		f.disc, nil, NewKeyPinStore(),
+		ctxFor([]string{"*.example.com"}, 0), "",
+	)
+	if !result.Valid {
+		t.Fatalf("expected valid, got %+v", result)
+	}
+}

--- a/go/pkg/verification/verification.go
+++ b/go/pkg/verification/verification.go
@@ -38,7 +38,35 @@ const (
 	ErrDiscoveryInvalid             ErrorCode = "discovery_invalid"
 	ErrDomainMismatch               ErrorCode = "domain_mismatch"
 	ErrSchemaCanonicalizationFailed ErrorCode = "schema_canonicalization_failed"
+	// ErrCanonicalizationUnsupported (v1.4 alpha.3) — signature declared a
+	// canonicalization algorithm this verifier does not support.
+	ErrCanonicalizationUnsupported ErrorCode = "canonicalization_unsupported"
+	// ErrA2AScopeViolation (v1.4 alpha.3) — A2A scope violation (provider
+	// domain not in caller's trusted_domains, or delegation_depth exceeded).
+	ErrA2AScopeViolation ErrorCode = "a2a_scope_violation"
 )
+
+// CanonicalizationV1 is the algorithm identifier (v1.4 alpha.3) for the
+// sorted-key, no-whitespace, UTF-8 canonicalization implemented in
+// core.SchemaPinCore. Signatures MAY carry a "canonicalization" field
+// naming the algorithm used to produce the signing input. Absence is
+// equivalent to this identifier for backward compatibility with v1.3
+// signatures. Verifiers MUST reject any other value as
+// ErrCanonicalizationUnsupported.
+const CanonicalizationV1 = "schemapin-v1"
+
+// CheckCanonicalization returns the empty string when `algorithm` names a
+// canonicalization algorithm this SDK supports, or the offending value
+// otherwise.
+//
+// An empty string input means the field is absent and is equivalent to the
+// default schemapin-v1 algorithm (v1.3 backward compatibility).
+func CheckCanonicalization(algorithm string) string {
+	if algorithm == "" || algorithm == CanonicalizationV1 {
+		return ""
+	}
+	return algorithm
+}
 
 // KeyPinningStatus represents the pinning status in a verification result.
 type KeyPinningStatus struct {
@@ -196,6 +224,10 @@ func FromJSON(jsonStr string) (*KeyPinStore, error) {
 // 5. Canonicalize schema and compute hash
 // 6. Verify ECDSA signature against hash
 // 7. Return structured result
+//
+// Use VerifySchemaOfflineWithCanonicalization when the signature carries
+// a v1.4 alpha.3 canonicalization algorithm identifier; this thin wrapper
+// passes the empty string (== default schemapin-v1).
 func VerifySchemaOffline(
 	schema map[string]interface{},
 	signatureB64 string,
@@ -205,6 +237,38 @@ func VerifySchemaOffline(
 	rev *revocation.RevocationDocument,
 	pinStore *KeyPinStore,
 ) *VerificationResult {
+	return VerifySchemaOfflineWithCanonicalization(
+		schema, signatureB64, domain, toolID, disc, rev, pinStore, "",
+	)
+}
+
+// VerifySchemaOfflineWithCanonicalization is VerifySchemaOffline plus the
+// optional v1.4 alpha.3 canonicalization algorithm parameter.
+//
+// `canonicalization` mirrors the optional "canonicalization" field on
+// .schemapin.sig documents. Empty string or "schemapin-v1" are equivalent
+// and accepted; any other value fails with ErrCanonicalizationUnsupported
+// before any crypto work.
+func VerifySchemaOfflineWithCanonicalization(
+	schema map[string]interface{},
+	signatureB64 string,
+	domain string,
+	toolID string,
+	disc *discovery.WellKnownResponse,
+	rev *revocation.RevocationDocument,
+	pinStore *KeyPinStore,
+	canonicalization string,
+) *VerificationResult {
+	// Step 0 (v1.4 alpha.3): canonicalization algorithm check.
+	if bad := CheckCanonicalization(canonicalization); bad != "" {
+		return &VerificationResult{
+			Valid:        false,
+			Domain:       domain,
+			ErrorCode:    ErrCanonicalizationUnsupported,
+			ErrorMessage: fmt.Sprintf("Unsupported canonicalization algorithm: %s", bad),
+		}
+	}
+
 	// Step 1: Validate discovery document
 	if disc == nil || disc.PublicKeyPEM == "" || !strings.Contains(disc.PublicKeyPEM, "-----BEGIN PUBLIC KEY-----") {
 		return &VerificationResult{
@@ -324,4 +388,68 @@ func VerifySchemaWithResolver(
 	rev, _ := r.ResolveRevocation(domain, disc)
 
 	return VerifySchemaOffline(schema, signatureB64, domain, toolID, disc, rev, pinStore)
+}
+
+// VerifySchemaForA2A verifies a schema in the context of an A2A interaction
+// (v1.4 alpha.3).
+//
+// Wraps VerifySchemaOfflineWithCanonicalization with an A2A scope check:
+//
+//  1. Reject when context.DelegationDepth > A2AMaxDelegationDepth.
+//     Surfaces as ErrA2AScopeViolation.
+//  2. Run the standard 7-step verification. If it fails, return that
+//     result unchanged.
+//  3. Reject when context.TrustedDomains is non-empty and domain is not
+//     allowed by it. Surfaces as ErrA2AScopeViolation.
+//
+// On success the returned VerificationResult is the result from step 2
+// unchanged — A2A context does not modify the cryptographic outcome, only
+// the policy outcome.
+func VerifySchemaForA2A(
+	schema map[string]interface{},
+	signatureB64 string,
+	domain string,
+	toolID string,
+	disc *discovery.WellKnownResponse,
+	rev *revocation.RevocationDocument,
+	pinStore *KeyPinStore,
+	context *A2AVerificationContext,
+	canonicalization string,
+) *VerificationResult {
+	if context != nil && context.DelegationDepth > A2AMaxDelegationDepth {
+		return &VerificationResult{
+			Valid:     false,
+			Domain:    domain,
+			ErrorCode: ErrA2AScopeViolation,
+			ErrorMessage: fmt.Sprintf(
+				"A2A delegation_depth %d exceeds cap of %d",
+				context.DelegationDepth, A2AMaxDelegationDepth,
+			),
+		}
+	}
+
+	result := VerifySchemaOfflineWithCanonicalization(
+		schema, signatureB64, domain, toolID, disc, rev, pinStore, canonicalization,
+	)
+	if !result.Valid {
+		return result
+	}
+
+	var trusted []string
+	if context != nil {
+		trusted = context.TrustedDomains
+	}
+	if !A2AAllows(trusted, domain) {
+		return &VerificationResult{
+			Valid:     false,
+			Domain:    domain,
+			ErrorCode: ErrA2AScopeViolation,
+			ErrorMessage: fmt.Sprintf(
+				"Provider domain '%s' not in caller's A2A trusted_domains scope",
+				domain,
+			),
+		}
+	}
+
+	return result
 }

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schemapin",
-  "version": "1.4.0-alpha.2",
+  "version": "1.4.0-alpha.3",
   "description": "Cryptographic schema integrity verification for AI tools",
   "main": "src/index.js",
   "type": "module",

--- a/javascript/src/a2a.js
+++ b/javascript/src/a2a.js
@@ -1,0 +1,142 @@
+/**
+ * @file A2A verification context for SchemaPin (v1.4 alpha.3).
+ *
+ * Mirrors the Rust `schemapin::types::a2a` module and the AgentPin v0.3
+ * `AllowedDomains` semantics (AgentPin technical specification §4.11).
+ *
+ * When a SchemaPin verification crosses an A2A (Agent-to-Agent) trust
+ * boundary, the verifier needs to scope the result to the intersection of
+ * *caller-trusted* domains and the *tool provider's* domain.
+ * {@link A2aVerificationContext} carries that scoping data; pair it with
+ * {@link verifySchemaForA2A}.
+ *
+ * ## AllowedDomains convention
+ *
+ * The allow-list semantics follow AgentPin v0.3 exactly:
+ *
+ * > An empty `trustedDomains` list means **unrestricted** — all domains
+ * > trusted. This is the opposite of the naïve set-theoretic interpretation
+ * > but matches v1.3 behaviour where an *omitted* `allowed_domains` field
+ * > allowed all domains.
+ *
+ * SchemaPin defines these helpers locally rather than depending on the
+ * `agentpin` npm package — keeping SchemaPin self-contained and avoiding a
+ * circular trust-stack dependency. Callers who *do* install both packages
+ * can pass the result of `agentpin.AllowedDomains.intersect(...)` into
+ * `trustedDomains` directly — the wire and in-memory shapes are identical.
+ */
+
+/**
+ * Scope a schema verification to an A2A interaction.
+ *
+ * Pair with {@link verifySchemaForA2A} (re-exported from `./verification.js`)
+ * to run the standard 7-step verification flow with the additional A2A
+ * scope check.
+ */
+export class A2aVerificationContext {
+    /**
+     * @param {Object} init
+     * @param {string} init.callerAgentId - Caller's agent identity (URN-style,
+     *   matching AgentPin). Informational only.
+     * @param {number} [init.delegationDepth=0] - Depth in the A2A delegation
+     *   chain (0 = direct caller). Verifiers SHOULD reject `> 3` to match
+     *   AgentPin's `max_delegation_depth` cap.
+     * @param {string} [init.originatingDomain=''] - Originating domain of the
+     *   A2A request. Informational.
+     * @param {string[]} [init.trustedDomains=[]] - Caller-trusted domains.
+     *   Empty list = unrestricted (all domains trusted) per AgentPin
+     *   convention.
+     */
+    constructor({ callerAgentId, delegationDepth = 0, originatingDomain = '', trustedDomains = [] }) {
+        this.callerAgentId = callerAgentId;
+        this.delegationDepth = delegationDepth;
+        this.originatingDomain = originatingDomain;
+        this.trustedDomains = [...trustedDomains];
+    }
+
+    /** Build a context placing no restriction on provider domains. */
+    static unrestricted(callerAgentId) {
+        return new A2aVerificationContext({ callerAgentId });
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// AllowedDomains helpers
+// ─────────────────────────────────────────────────────────────────────────
+//
+// Spec source of truth: AgentPin technical specification §4.11. This module
+// re-implements the helpers locally rather than linking the agentpin npm
+// package (see module docs above for rationale). Update both projects in
+// lockstep if the convention ever changes.
+
+/**
+ * `true` when `list` is empty / null / undefined (no restriction).
+ *
+ * @param {string[]|null|undefined} list
+ * @returns {boolean}
+ */
+export function a2aIsUnrestricted(list) {
+    return !list || list.length === 0;
+}
+
+/**
+ * `true` when `domain` is permitted under `list`.
+ *
+ * An empty `list` allows everything. A non-empty list allows `domain` when
+ * it exactly matches an entry OR matches one of the entry's wildcard
+ * patterns. Pattern matching follows AgentPin spec §5.5: a leading `*.`
+ * matches any subdomain (e.g. `*.client.com` matches `api.client.com` but
+ * NOT `client.com` itself).
+ *
+ * @param {string[]|null|undefined} list
+ * @param {string} domain
+ * @returns {boolean}
+ */
+export function a2aAllows(list, domain) {
+    if (a2aIsUnrestricted(list)) {
+        return true;
+    }
+    return list.some((pattern) => patternMatches(pattern, domain));
+}
+
+/**
+ * Intersection of two allow-lists honouring the empty-is-unrestricted
+ * convention.
+ *
+ * - `unrestricted ∩ X = X`
+ * - `X ∩ unrestricted = X`
+ * - Otherwise: literal set intersection (string equality; no wildcard
+ *   expansion), preserving the order of `lhs`.
+ *
+ * An intersection that yields an empty list from two non-empty inputs is
+ * *re-interpreted as unrestricted* under the same convention — see AgentPin
+ * spec §4.11.4. Callers needing to distinguish "intentionally restricted to
+ * nothing" from "no restriction" must track that outside the value.
+ *
+ * @param {string[]|null|undefined} lhs
+ * @param {string[]|null|undefined} rhs
+ * @returns {string[]}
+ */
+export function a2aIntersect(lhs, rhs) {
+    if (a2aIsUnrestricted(lhs)) return rhs ? [...rhs] : [];
+    if (a2aIsUnrestricted(rhs)) return [...lhs];
+    const rhsSet = new Set(rhs);
+    return lhs.filter((d) => rhsSet.has(d));
+}
+
+/**
+ * Wildcard-aware domain pattern matcher.
+ *
+ * `*.example.com` matches `api.example.com` and `a.b.example.com` but NOT
+ * `example.com` itself. Anything without a leading `*.` is a literal
+ * equality check.
+ */
+function patternMatches(pattern, domain) {
+    if (pattern.startsWith('*.')) {
+        const suffix = pattern.slice(2);
+        if (domain.length <= suffix.length) return false;
+        if (!domain.endsWith(suffix)) return false;
+        return domain[domain.length - suffix.length - 1] === '.';
+    }
+    return pattern === domain;
+}

--- a/javascript/src/index.js
+++ b/javascript/src/index.js
@@ -50,8 +50,21 @@ export {
     KeyPinStore,
     verifySchemaOffline,
     verifySchemaWithResolver,
-    applyExpirationCheck
+    applyExpirationCheck,
+    // v1.4 alpha.3
+    CANONICALIZATION_V1,
+    checkCanonicalization,
+    A2A_MAX_DELEGATION_DEPTH,
+    verifySchemaForA2A
 } from './verification.js';
+
+// v1.4 alpha.3: A2A verification context
+export {
+    A2aVerificationContext,
+    a2aIsUnrestricted,
+    a2aAllows,
+    a2aIntersect
+} from './a2a.js';
 
 // v1.3.0 new module
 export {

--- a/javascript/src/skill.js
+++ b/javascript/src/skill.js
@@ -15,7 +15,7 @@ import { readFileSync, readdirSync, writeFileSync, lstatSync, existsSync } from 
 import { join, relative, basename, resolve } from 'node:path';
 import { KeyManager, SignatureManager } from './crypto.js';
 import { checkRevocationCombined } from './revocation.js';
-import { ErrorCode, applyExpirationCheck } from './verification.js';
+import { ErrorCode, applyExpirationCheck, checkCanonicalization } from './verification.js';
 import { verifyDnsMatch } from './dns.js';
 
 export const SIGNATURE_FILENAME = '.schemapin.sig';
@@ -283,7 +283,11 @@ export function signSkillWithOptions(skillDir, privateKeyPem, domain, options = 
         schemaVersion = null,
         // v1.4 alpha.2: `sha256:<hex>` of the prior signed version's
         // `skill_hash`, forming a hash chain. Pair with `verifyChain`.
-        previousHash = null
+        previousHash = null,
+        // v1.4 alpha.3: canonicalization algorithm identifier written to the
+        // signature. `null` is wire-equivalent to the implicit "schemapin-v1"
+        // default; pass `'schemapin-v1'` to declare it explicitly.
+        canonicalization = null
     } = options;
 
     const skillPath = resolve(skillDir);
@@ -317,7 +321,8 @@ export function signSkillWithOptions(skillDir, privateKeyPem, domain, options = 
     const usesV14Field =
         expiresAt !== null
         || (schemaVersion !== null && schemaVersion !== undefined)
-        || (previousHash !== null && previousHash !== undefined);
+        || (previousHash !== null && previousHash !== undefined)
+        || (canonicalization !== null && canonicalization !== undefined);
     const version = usesV14Field ? SCHEMAPIN_VERSION_V14 : SCHEMAPIN_VERSION_V13;
 
     // Build the document in canonical field order. Optional v1.4 fields slot
@@ -337,6 +342,9 @@ export function signSkillWithOptions(skillDir, privateKeyPem, domain, options = 
     }
     if (previousHash !== null && previousHash !== undefined) {
         ordered.previous_hash = previousHash;
+    }
+    if (canonicalization !== null && canonicalization !== undefined) {
+        ordered.canonicalization = canonicalization;
     }
     ordered.domain = domain;
     ordered.signer_kid = signerKid;
@@ -386,6 +394,17 @@ export function verifySkillOffline(skillDir, discovery, signatureData = null, re
     const domain = signatureData.domain || '';
     if (toolId === null || toolId === undefined) {
         toolId = signatureData.skill_name || basename(skillPath);
+    }
+
+    // Step 1a (v1.4 alpha.3): canonicalization algorithm check.
+    const unsupportedAlgo = checkCanonicalization(signatureData.canonicalization);
+    if (unsupportedAlgo !== null) {
+        return {
+            valid: false,
+            domain,
+            error_code: ErrorCode.CANONICALIZATION_UNSUPPORTED,
+            error_message: `Unsupported canonicalization algorithm: ${unsupportedAlgo}`
+        };
     }
 
     // Step 2: Validate discovery document

--- a/javascript/src/verification.js
+++ b/javascript/src/verification.js
@@ -5,6 +5,7 @@
 import { SchemaPinCore } from './core.js';
 import { KeyManager, SignatureManager } from './crypto.js';
 import { checkRevocationCombined } from './revocation.js';
+import { a2aAllows } from './a2a.js';
 
 /**
  * Apply a signature `expires_at` check to a verification result (v1.4).
@@ -56,8 +57,42 @@ export const ErrorCode = Object.freeze({
     DISCOVERY_FETCH_FAILED: 'discovery_fetch_failed',
     DISCOVERY_INVALID: 'discovery_invalid',
     DOMAIN_MISMATCH: 'domain_mismatch',
-    SCHEMA_CANONICALIZATION_FAILED: 'schema_canonicalization_failed'
+    SCHEMA_CANONICALIZATION_FAILED: 'schema_canonicalization_failed',
+    // v1.4 alpha.3: signature declared a canonicalization algorithm this
+    // verifier does not support. Hard failure.
+    CANONICALIZATION_UNSUPPORTED: 'canonicalization_unsupported',
+    // v1.4 alpha.3: A2A scope violation (provider domain not in caller's
+    // trusted_domains, or delegation_depth exceeded).
+    A2A_SCOPE_VIOLATION: 'a2a_scope_violation'
 });
+
+/**
+ * v1.4 alpha.3: canonicalization algorithm identifier.
+ *
+ * Signatures MAY carry a `canonicalization` field naming the algorithm used
+ * to produce the signing input. Absence is equivalent to this identifier
+ * for backward compatibility with v1.3 signatures. Verifiers MUST reject
+ * any other value as `CANONICALIZATION_UNSUPPORTED`.
+ */
+export const CANONICALIZATION_V1 = 'schemapin-v1';
+
+/**
+ * Returns `null` when `algorithm` is supported, or the offending value
+ * otherwise. The caller surfaces a non-null return as
+ * `ErrorCode.CANONICALIZATION_UNSUPPORTED`.
+ *
+ * `null` / `undefined` are equivalent to the implicit `schemapin-v1`
+ * default and are accepted (v1.3 backward compatibility).
+ *
+ * @param {string|null|undefined} algorithm
+ * @returns {string|null}
+ */
+export function checkCanonicalization(algorithm) {
+    if (algorithm === null || algorithm === undefined || algorithm === CANONICALIZATION_V1) {
+        return null;
+    }
+    return algorithm;
+}
 
 /**
  * Lightweight in-memory fingerprint-based pin store.
@@ -148,9 +183,24 @@ export class KeyPinStore {
  * @param {Object} discovery - Well-known response
  * @param {Object|null} revocation - Standalone revocation document
  * @param {KeyPinStore} pinStore
+ * @param {string|null} [canonicalization] - v1.4 alpha.3 optional canonicalization
+ *   algorithm identifier from the signature. `null` / `undefined` /
+ *   `'schemapin-v1'` are equivalent and accepted; any other value fails with
+ *   `CANONICALIZATION_UNSUPPORTED`.
  * @returns {Object} Verification result
  */
-export function verifySchemaOffline(schema, signatureB64, domain, toolId, discovery, revocation, pinStore) {
+export function verifySchemaOffline(schema, signatureB64, domain, toolId, discovery, revocation, pinStore, canonicalization = null) {
+    // Step 0 (v1.4 alpha.3): canonicalization algorithm check
+    const unsupportedAlgo = checkCanonicalization(canonicalization);
+    if (unsupportedAlgo !== null) {
+        return {
+            valid: false,
+            domain,
+            error_code: ErrorCode.CANONICALIZATION_UNSUPPORTED,
+            error_message: `Unsupported canonicalization algorithm: ${unsupportedAlgo}`
+        };
+    }
+
     // Step 1: Validate discovery document
     const publicKeyPem = discovery?.public_key_pem;
     if (!publicKeyPem || !publicKeyPem.includes('-----BEGIN PUBLIC KEY-----')) {
@@ -269,4 +319,92 @@ export async function verifySchemaWithResolver(schema, signatureB64, domain, too
     const revocation = await resolver.resolveRevocation(domain, discovery);
 
     return verifySchemaOffline(schema, signatureB64, domain, toolId, discovery, revocation, pinStore);
+}
+
+/**
+ * Maximum A2A delegation depth allowed by this verifier (v1.4 alpha.3).
+ *
+ * Mirrors the AgentPin `max_delegation_depth` cap (AgentPin spec §4.3).
+ * Bumping this on the SchemaPin side without a matching bump on AgentPin
+ * would let SchemaPin accept chains AgentPin would reject — keep in lockstep.
+ */
+export const A2A_MAX_DELEGATION_DEPTH = 3;
+
+/**
+ * Verify a schema in the context of an A2A interaction (v1.4 alpha.3).
+ *
+ * Wraps {@link verifySchemaOffline} with an A2A scope check:
+ *
+ *   1. Reject when `context.delegationDepth > A2A_MAX_DELEGATION_DEPTH`.
+ *      Surfaces as `A2A_SCOPE_VIOLATION`.
+ *   2. Run the standard 7-step verification. If it fails, return that
+ *      result unchanged.
+ *   3. Reject when `context.trustedDomains` is non-empty and `domain` is
+ *      not allowed by it. Surfaces as `A2A_SCOPE_VIOLATION`.
+ *
+ * On success the returned result is the result from step 2 unchanged — A2A
+ * context does not modify the cryptographic outcome, only the policy
+ * outcome.
+ *
+ * @param {Object} schema
+ * @param {string} signatureB64
+ * @param {string} domain
+ * @param {string} toolId
+ * @param {Object} discovery
+ * @param {Object|null} revocation
+ * @param {KeyPinStore} pinStore
+ * @param {import('./a2a.js').A2aVerificationContext} context
+ * @param {string|null} [canonicalization=null]
+ * @returns {Object} Verification result
+ */
+export function verifySchemaForA2A(
+    schema,
+    signatureB64,
+    domain,
+    toolId,
+    discovery,
+    revocation,
+    pinStore,
+    context,
+    canonicalization = null,
+) {
+    // Async import would force the public function to be async; instead use
+    // a lazy require-style approach via dynamic await. Since a2a.js has no
+    // side effects and tiny size, eager static import below is fine — JS
+    // can't tree-shake conditionally either way.
+    // (See bottom of file for the import.)
+    if (context.delegationDepth > A2A_MAX_DELEGATION_DEPTH) {
+        return {
+            valid: false,
+            domain,
+            error_code: ErrorCode.A2A_SCOPE_VIOLATION,
+            error_message:
+                `A2A delegation_depth ${context.delegationDepth} exceeds cap of ${A2A_MAX_DELEGATION_DEPTH}`
+        };
+    }
+
+    const result = verifySchemaOffline(
+        schema,
+        signatureB64,
+        domain,
+        toolId,
+        discovery,
+        revocation,
+        pinStore,
+        canonicalization,
+    );
+    if (!result.valid) {
+        return result;
+    }
+
+    if (!a2aAllows(context.trustedDomains, domain)) {
+        return {
+            valid: false,
+            domain,
+            error_code: ErrorCode.A2A_SCOPE_VIOLATION,
+            error_message: `Provider domain '${domain}' not in caller's A2A trusted_domains scope`
+        };
+    }
+
+    return result;
 }

--- a/javascript/tests/a2a.test.js
+++ b/javascript/tests/a2a.test.js
@@ -1,0 +1,239 @@
+/**
+ * Tests for v1.4 alpha.3 canonicalization id + A2A verification context.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { KeyManager, SignatureManager } from '../src/crypto.js';
+import { SchemaPinCore } from '../src/core.js';
+import {
+    ErrorCode,
+    KeyPinStore,
+    verifySchemaOffline,
+    verifySchemaForA2A,
+    checkCanonicalization,
+    CANONICALIZATION_V1,
+    A2A_MAX_DELEGATION_DEPTH
+} from '../src/verification.js';
+import {
+    A2aVerificationContext,
+    a2aAllows,
+    a2aIntersect,
+    a2aIsUnrestricted
+} from '../src/a2a.js';
+
+// ─────────────────────────────────────────────────────────────────────
+// AllowedDomains helpers (mirrors AgentPin v0.3 §4.11 semantics)
+// ─────────────────────────────────────────────────────────────────────
+
+describe('AllowedDomains helpers', () => {
+    it('empty is unrestricted', () => {
+        assert.equal(a2aIsUnrestricted([]), true);
+        assert.equal(a2aIsUnrestricted(null), true);
+        assert.equal(a2aIsUnrestricted(undefined), true);
+    });
+
+    it('unrestricted allows anything', () => {
+        assert.equal(a2aAllows([], 'literally-anything'), true);
+    });
+
+    it('restricted filters', () => {
+        const ad = ['api.client.com', '*.partner.com'];
+        assert.equal(a2aAllows(ad, 'api.client.com'), true);
+        assert.equal(a2aAllows(ad, 'tools.partner.com'), true);
+        assert.equal(a2aAllows(ad, 'partner.com'), false); // *.partner.com excludes bare
+        assert.equal(a2aAllows(ad, 'evil.example.com'), false);
+    });
+
+    it('intersect with unrestricted returns other', () => {
+        assert.deepEqual(a2aIntersect([], ['a.com', 'b.com']), ['a.com', 'b.com']);
+        assert.deepEqual(a2aIntersect(['a.com', 'b.com'], []), ['a.com', 'b.com']);
+    });
+
+    it('intersect returns overlap', () => {
+        assert.deepEqual(
+            a2aIntersect(['a.com', 'b.com', 'c.com'], ['b.com', 'c.com', 'd.com']),
+            ['b.com', 'c.com']
+        );
+    });
+
+    it('intersect empty overlap is unrestricted per spec', () => {
+        const result = a2aIntersect(['a.com'], ['b.com']);
+        assert.deepEqual(result, []);
+        assert.equal(a2aIsUnrestricted(result), true);
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Canonicalization algorithm identifier
+// ─────────────────────────────────────────────────────────────────────
+
+describe('checkCanonicalization', () => {
+    it('absent is supported', () => {
+        assert.equal(checkCanonicalization(null), null);
+        assert.equal(checkCanonicalization(undefined), null);
+    });
+
+    it('v1 is supported', () => {
+        assert.equal(checkCanonicalization(CANONICALIZATION_V1), null);
+        assert.equal(checkCanonicalization('schemapin-v1'), null);
+    });
+
+    it('unknown returns offending value', () => {
+        assert.equal(checkCanonicalization('schemapin-v999'), 'schemapin-v999');
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Signed-schema fixture
+// ─────────────────────────────────────────────────────────────────────
+
+function setupSchema() {
+    const { privateKey, publicKey } = KeyManager.generateKeypair();
+    const pubPem = KeyManager.exportPublicKeyPem(publicKey);
+    const schema = {
+        name: 'calculate_sum',
+        description: 'Calculates the sum of two numbers',
+        parameters: { a: 'integer', b: 'integer' }
+    };
+    const schemaHash = SchemaPinCore.canonicalizeAndHash(schema);
+    const sig = SignatureManager.signSchemaHash(schemaHash, privateKey);
+    return {
+        schema,
+        sig,
+        discovery: {
+            schema_version: '1.2',
+            developer_name: 'Test Developer',
+            public_key_pem: pubPem,
+            revoked_keys: []
+        }
+    };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// verifySchemaOffline with canonicalization parameter
+// ─────────────────────────────────────────────────────────────────────
+
+describe('verifySchemaOffline canonicalization', () => {
+    it('absent canonicalization accepted', () => {
+        const f = setupSchema();
+        const result = verifySchemaOffline(
+            f.schema, f.sig, 'example.com', 'calculate_sum',
+            f.discovery, null, new KeyPinStore()
+        );
+        assert.equal(result.valid, true);
+    });
+
+    it('v1 canonicalization accepted', () => {
+        const f = setupSchema();
+        const result = verifySchemaOffline(
+            f.schema, f.sig, 'example.com', 'calculate_sum',
+            f.discovery, null, new KeyPinStore(),
+            CANONICALIZATION_V1
+        );
+        assert.equal(result.valid, true);
+    });
+
+    it('unknown canonicalization rejected', () => {
+        const f = setupSchema();
+        const result = verifySchemaOffline(
+            f.schema, f.sig, 'example.com', 'calculate_sum',
+            f.discovery, null, new KeyPinStore(),
+            'schemapin-v999'
+        );
+        assert.equal(result.valid, false);
+        assert.equal(result.error_code, ErrorCode.CANONICALIZATION_UNSUPPORTED);
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// verifySchemaForA2A
+// ─────────────────────────────────────────────────────────────────────
+
+function ctx(trusted, depth = 0) {
+    return new A2aVerificationContext({
+        callerAgentId: 'urn:agentpin:caller.com:test',
+        delegationDepth: depth,
+        originatingDomain: 'caller.com',
+        trustedDomains: trusted
+    });
+}
+
+describe('verifySchemaForA2A', () => {
+    it('unrestricted caller allows any provider', () => {
+        const f = setupSchema();
+        const result = verifySchemaForA2A(
+            f.schema, f.sig, 'example.com', 'calculate_sum',
+            f.discovery, null, new KeyPinStore(),
+            ctx([])
+        );
+        assert.equal(result.valid, true, JSON.stringify(result));
+    });
+
+    it('caller allow-list includes provider', () => {
+        const f = setupSchema();
+        const result = verifySchemaForA2A(
+            f.schema, f.sig, 'example.com', 'calculate_sum',
+            f.discovery, null, new KeyPinStore(),
+            ctx(['example.com', 'other.com'])
+        );
+        assert.equal(result.valid, true);
+    });
+
+    it('provider outside caller scope rejected', () => {
+        const f = setupSchema();
+        const result = verifySchemaForA2A(
+            f.schema, f.sig, 'example.com', 'calculate_sum',
+            f.discovery, null, new KeyPinStore(),
+            ctx(['other.com'])
+        );
+        assert.equal(result.valid, false);
+        assert.equal(result.error_code, ErrorCode.A2A_SCOPE_VIOLATION);
+    });
+
+    it('delegation_depth cap enforced', () => {
+        const f = setupSchema();
+        const result = verifySchemaForA2A(
+            f.schema, f.sig, 'example.com', 'calculate_sum',
+            f.discovery, null, new KeyPinStore(),
+            ctx([], A2A_MAX_DELEGATION_DEPTH + 1)
+        );
+        assert.equal(result.valid, false);
+        assert.equal(result.error_code, ErrorCode.A2A_SCOPE_VIOLATION);
+    });
+
+    it('underlying signature failure passes through', () => {
+        const f = setupSchema();
+        const result = verifySchemaForA2A(
+            f.schema, 'bm90LWEtdmFsaWQtc2lnbmF0dXJl', 'example.com', 'calculate_sum',
+            f.discovery, null, new KeyPinStore(),
+            ctx([])
+        );
+        assert.equal(result.valid, false);
+        // Underlying error surfaces, not A2A_SCOPE_VIOLATION
+        assert.equal(result.error_code, ErrorCode.SIGNATURE_INVALID);
+    });
+
+    it('canonicalization unknown rejected through A2A', () => {
+        const f = setupSchema();
+        const result = verifySchemaForA2A(
+            f.schema, f.sig, 'example.com', 'calculate_sum',
+            f.discovery, null, new KeyPinStore(),
+            ctx([]),
+            'schemapin-v999'
+        );
+        assert.equal(result.valid, false);
+        assert.equal(result.error_code, ErrorCode.CANONICALIZATION_UNSUPPORTED);
+    });
+
+    it('wildcard provider in caller trusted list', () => {
+        const f = setupSchema();
+        const result = verifySchemaForA2A(
+            f.schema, f.sig, 'api.example.com', 'calculate_sum',
+            f.discovery, null, new KeyPinStore(),
+            ctx(['*.example.com'])
+        );
+        assert.equal(result.valid, true, JSON.stringify(result));
+    });
+});

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schemapin"
-version = "1.4.0a2"
+version = "1.4.0a3"
 description = "Cryptographic schema integrity verification for AI tools"
 readme = "README.md"
 license = {text = "MIT"}

--- a/python/schemapin/__init__.py
+++ b/python/schemapin/__init__.py
@@ -54,15 +54,25 @@ from .utils import (
     create_well_known_response,
 )
 from .verification import (
+    A2A_MAX_DELEGATION_DEPTH,
+    CANONICALIZATION_V1,
     ErrorCode,
     KeyPinningStatus,
     KeyPinStore,
     VerificationResult,
+    check_canonicalization,
+    verify_schema_for_a2a,
     verify_schema_offline,
     verify_schema_with_resolver,
 )
+from .a2a import (
+    A2aVerificationContext,
+    allows as a2a_allows,
+    intersect as a2a_intersect,
+    is_unrestricted as a2a_is_unrestricted,
+)
 
-__version__ = "1.4.0a2"
+__version__ = "1.4.0a3"
 __all__ = [
     "SchemaPinCore",
     "KeyManager",
@@ -115,4 +125,13 @@ __all__ = [
     "verify_dns_match",
     "txt_record_name",
     "fetch_dns_txt",
+    # v1.4 alpha.3
+    "CANONICALIZATION_V1",
+    "check_canonicalization",
+    "A2A_MAX_DELEGATION_DEPTH",
+    "verify_schema_for_a2a",
+    "A2aVerificationContext",
+    "a2a_allows",
+    "a2a_intersect",
+    "a2a_is_unrestricted",
 ]

--- a/python/schemapin/a2a.py
+++ b/python/schemapin/a2a.py
@@ -1,0 +1,141 @@
+"""A2A verification context for SchemaPin (v1.4 alpha.3).
+
+Mirrors the Rust ``schemapin::types::a2a`` module and the AgentPin v0.3
+``AllowedDomains`` semantics (AgentPin technical specification §4.11).
+
+When a SchemaPin verification crosses an A2A (Agent-to-Agent) trust boundary,
+the verifier needs to scope the result to the intersection of *caller-trusted*
+domains and the *tool provider's* domain. ``A2aVerificationContext`` carries
+that scoping data; pair it with :func:`schemapin.verification.verify_schema_for_a2a`.
+
+AllowedDomains convention
+-------------------------
+
+The allow-list semantics follow AgentPin v0.3 exactly:
+
+    An empty ``trusted_domains`` list means *unrestricted* — all domains
+    trusted. This is the opposite of the naïve set-theoretic interpretation
+    (where an empty set allows nothing) but it matches the existing v1.3
+    behaviour where an *omitted* ``allowed_domains`` field allowed all
+    domains.
+
+SchemaPin defines these helpers locally rather than depending on the
+``agentpin`` Python package — keeping SchemaPin self-contained for users
+who only consume tool-integrity, and avoiding a circular trust-stack
+dependency. Callers who *do* install both packages can pass the result of
+``agentpin.AllowedDomains.intersect(...)`` directly into
+``A2aVerificationContext(trusted_domains=...)`` — the wire and in-memory
+shapes are identical.
+"""
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Optional
+
+
+@dataclass
+class A2aVerificationContext:
+    """Scope a schema verification to an A2A interaction.
+
+    Pair with :func:`schemapin.verification.verify_schema_for_a2a` to run
+    the standard 7-step verification flow with the additional A2A scope
+    check.
+    """
+
+    #: Caller's agent identity (URN-style, matching AgentPin). Informational
+    #: only — SchemaPin does not validate the URN shape.
+    caller_agent_id: str
+
+    #: Depth in the A2A delegation chain. ``0`` = direct caller.
+    #: Verifiers SHOULD reject ``delegation_depth > 3`` to match the AgentPin
+    #: ``max_delegation_depth`` cap (AgentPin spec §4.3).
+    delegation_depth: int = 0
+
+    #: Originating domain of the A2A request. Informational; the scope check
+    #: uses ``trusted_domains`` vs. tool provider domain.
+    originating_domain: str = ""
+
+    #: Caller-trusted domains. Uses the AgentPin convention: an empty list
+    #: means *unrestricted* (all domains trusted), not "deny-all".
+    trusted_domains: List[str] = field(default_factory=list)
+
+    @classmethod
+    def unrestricted(cls, caller_agent_id: str) -> "A2aVerificationContext":
+        """Build a context placing no restriction on provider domains."""
+        return cls(
+            caller_agent_id=caller_agent_id,
+            delegation_depth=0,
+            originating_domain="",
+            trusted_domains=[],
+        )
+
+
+# ---------------------------------------------------------------------------
+# AllowedDomains helpers
+# ---------------------------------------------------------------------------
+#
+# Spec source of truth: AgentPin technical specification §4.11. This module
+# re-implements the helpers locally rather than depending on the agentpin
+# package (see module-level docs for rationale). Update both projects in
+# lockstep if the convention ever changes.
+
+
+def is_unrestricted(list_: Optional[List[str]]) -> bool:
+    """``True`` when ``list_`` is empty (no restriction)."""
+    return not list_
+
+
+def allows(list_: Optional[List[str]], domain: str) -> bool:
+    """``True`` when ``domain`` is permitted under ``list_``.
+
+    An empty ``list_`` allows everything. A non-empty list allows ``domain``
+    when it exactly matches an entry OR matches one of the entry's wildcard
+    patterns. Pattern matching follows AgentPin spec §5.5: a leading ``*.``
+    matches any subdomain (e.g. ``*.client.com`` matches ``api.client.com``
+    but not ``client.com`` itself).
+    """
+    if is_unrestricted(list_):
+        return True
+    return any(_pattern_matches(p, domain) for p in list_)
+
+
+def intersect(lhs: Optional[Iterable[str]], rhs: Optional[Iterable[str]]) -> List[str]:
+    """Intersection of two allow-lists honouring the ``empty = unrestricted``
+    convention.
+
+    - ``unrestricted ∩ X = X``
+    - ``X ∩ unrestricted = X``
+    - Otherwise: literal set intersection (string equality; no wildcard
+      expansion), preserving the order of ``lhs``.
+
+    An intersection that yields an empty list from two non-empty inputs is
+    *re-interpreted as unrestricted* under the same convention — see
+    AgentPin spec §4.11.4. Callers needing to distinguish "intentionally
+    restricted to nothing" from "no restriction" must track that outside
+    the allow-list value.
+    """
+    lhs_list = list(lhs) if lhs is not None else []
+    rhs_list = list(rhs) if rhs is not None else []
+    if is_unrestricted(lhs_list):
+        return list(rhs_list)
+    if is_unrestricted(rhs_list):
+        return list(lhs_list)
+    rhs_set = set(rhs_list)
+    return [d for d in lhs_list if d in rhs_set]
+
+
+def _pattern_matches(pattern: str, domain: str) -> bool:
+    """Wildcard-aware domain pattern matcher.
+
+    ``*.example.com`` matches ``api.example.com`` and ``a.b.example.com`` but
+    NOT ``example.com`` itself. Anything without a leading ``*.`` is a
+    literal equality check.
+    """
+    if pattern.startswith("*."):
+        suffix = pattern[2:]
+        if len(domain) <= len(suffix):
+            return False
+        if not domain.endswith(suffix):
+            return False
+        # Char before the suffix must be a literal '.'
+        return domain[-(len(suffix) + 1)] == "."
+    return pattern == domain

--- a/python/schemapin/skill.py
+++ b/python/schemapin/skill.py
@@ -31,6 +31,7 @@ from .verification import (
     KeyPinningStatus,
     KeyPinStore,
     VerificationResult,
+    check_canonicalization,
 )
 
 SIGNATURE_FILENAME = ".schemapin.sig"
@@ -61,6 +62,10 @@ class SignOptions:
     # v1.4 alpha.2: ``sha256:<hex>`` of the prior signed version's
     # ``skill_hash``, forming a hash chain. Pair with :func:`verify_chain`.
     previous_hash: Optional[str] = None
+    # v1.4 alpha.3: canonicalization algorithm identifier written to the
+    # signature. ``None`` is wire-equivalent to the implicit "schemapin-v1"
+    # default; pass ``"schemapin-v1"`` to declare it explicitly.
+    canonicalization: Optional[str] = None
 
 
 class SkillSigner:
@@ -239,6 +244,7 @@ class SkillSigner:
             expires_at is not None
             or options.schema_version is not None
             or options.previous_hash is not None
+            or options.canonicalization is not None
         )
         version = SCHEMAPIN_VERSION_V1_4 if uses_v1_4_field else SCHEMAPIN_VERSION
 
@@ -260,6 +266,8 @@ class SkillSigner:
             sig_doc["schema_version"] = options.schema_version
         if options.previous_hash is not None:
             sig_doc["previous_hash"] = options.previous_hash
+        if options.canonicalization is not None:
+            sig_doc["canonicalization"] = options.canonicalization
 
         sig_path = skill_path / SIGNATURE_FILENAME
         sig_path.write_text(
@@ -303,6 +311,16 @@ class SkillSigner:
         domain = signature_data.get("domain", "")
         if tool_id is None:
             tool_id = signature_data.get("skill_name", skill_path.name)
+
+        # Step 1a (v1.4 alpha.3): canonicalization algorithm check.
+        unsupported = check_canonicalization(signature_data.get("canonicalization"))
+        if unsupported is not None:
+            return VerificationResult(
+                valid=False,
+                domain=domain,
+                error_code=ErrorCode.CANONICALIZATION_UNSUPPORTED,
+                error_message=f"Unsupported canonicalization algorithm: {unsupported}",
+            )
 
         # Step 2: Validate discovery document
         public_key_pem = discovery.get("public_key_pem")

--- a/python/schemapin/verification.py
+++ b/python/schemapin/verification.py
@@ -23,6 +23,33 @@ class ErrorCode(Enum):
     DISCOVERY_INVALID = "discovery_invalid"
     DOMAIN_MISMATCH = "domain_mismatch"
     SCHEMA_CANONICALIZATION_FAILED = "schema_canonicalization_failed"
+    # v1.4 alpha.3: signature declared a canonicalization algorithm this
+    # verifier does not support. Hard failure.
+    CANONICALIZATION_UNSUPPORTED = "canonicalization_unsupported"
+    # v1.4 alpha.3: A2A scope violation (provider domain not in caller's
+    # trusted_domains, or delegation_depth exceeded).
+    A2A_SCOPE_VIOLATION = "a2a_scope_violation"
+
+
+# v1.4 alpha.3: canonicalization algorithm identifier
+#
+# Signatures MAY carry a ``canonicalization`` field naming the algorithm used
+# to produce the signing input. Absence is equivalent to ``CANONICALIZATION_V1``
+# for backward compatibility with v1.3 signatures. Verifiers MUST reject any
+# other value as ``CANONICALIZATION_UNSUPPORTED``.
+CANONICALIZATION_V1 = "schemapin-v1"
+
+
+def check_canonicalization(algorithm: Optional[str]) -> Optional[str]:
+    """Return ``None`` when ``algorithm`` is supported, or the offending value.
+
+    ``None`` or ``"schemapin-v1"`` are equivalent and supported. Any other
+    value is unsupported and the caller surfaces it as
+    ``ErrorCode.CANONICALIZATION_UNSUPPORTED``.
+    """
+    if algorithm is None or algorithm == CANONICALIZATION_V1:
+        return None
+    return algorithm
 
 
 @dataclass
@@ -212,6 +239,7 @@ def verify_schema_offline(
     discovery: Dict[str, Any],
     revocation: Optional[RevocationDocument],
     pin_store: KeyPinStore,
+    canonicalization: Optional[str] = None,
 ) -> VerificationResult:
     """Verify a schema offline using pre-fetched discovery and revocation data.
 
@@ -223,7 +251,23 @@ def verify_schema_offline(
     5. Canonicalize schema and compute hash
     6. Verify ECDSA signature against hash
     7. Return structured result
+
+    ``canonicalization`` is a v1.4 alpha.3 addition: when the signature
+    carries a ``canonicalization`` field, the caller passes the value through
+    to this function. ``None`` or ``"schemapin-v1"`` are equivalent and
+    accepted; any other value fails with ``CANONICALIZATION_UNSUPPORTED``
+    before any crypto work.
     """
+    # Step 0 (v1.4): canonicalization algorithm check
+    unsupported = check_canonicalization(canonicalization)
+    if unsupported is not None:
+        return VerificationResult(
+            valid=False,
+            domain=domain,
+            error_code=ErrorCode.CANONICALIZATION_UNSUPPORTED,
+            error_message=f"Unsupported canonicalization algorithm: {unsupported}",
+        )
+
     # Step 1: Validate discovery document
     public_key_pem = discovery.get("public_key_pem")
     if not public_key_pem or "-----BEGIN PUBLIC KEY-----" not in public_key_pem:
@@ -341,3 +385,80 @@ def verify_schema_with_resolver(
     return verify_schema_offline(
         schema, signature_b64, domain, tool_id, discovery, revocation, pin_store
     )
+
+
+# v1.4 alpha.3 — A2A context verification
+#
+# Mirrors AgentPin's max_delegation_depth cap (AgentPin spec §4.3). Bumping
+# this on the SchemaPin side without a matching bump on AgentPin would let
+# SchemaPin accept chains AgentPin would reject — keep in lockstep.
+A2A_MAX_DELEGATION_DEPTH = 3
+
+
+def verify_schema_for_a2a(
+    schema: Dict[str, Any],
+    signature_b64: str,
+    domain: str,
+    tool_id: str,
+    discovery: Dict[str, Any],
+    revocation: Optional[RevocationDocument],
+    pin_store: KeyPinStore,
+    context,  # forward reference to schemapin.a2a.A2aVerificationContext
+    canonicalization: Optional[str] = None,
+) -> VerificationResult:
+    """Verify a schema in the context of an A2A interaction (v1.4 alpha.3).
+
+    Wraps :func:`verify_schema_offline` with an A2A scope check:
+
+    1. Reject when ``context.delegation_depth > A2A_MAX_DELEGATION_DEPTH``.
+       Surfaces as ``A2A_SCOPE_VIOLATION``.
+    2. Run the standard 7-step verification. If it fails, return that
+       result unchanged.
+    3. Reject when ``context.trusted_domains`` is non-empty and ``domain``
+       is not allowed by it. Surfaces as ``A2A_SCOPE_VIOLATION``.
+
+    On success the returned :class:`VerificationResult` is the result from
+    step 2 unchanged — A2A context does not modify the cryptographic
+    outcome, only the policy outcome.
+    """
+    # Local import to avoid a circular dependency: schemapin.a2a doesn't
+    # depend on verification, and we don't want verification to require a2a
+    # at import time for callers that don't use the A2A surface.
+    from .a2a import allows as a2a_allows
+
+    if context.delegation_depth > A2A_MAX_DELEGATION_DEPTH:
+        return VerificationResult(
+            valid=False,
+            domain=domain,
+            error_code=ErrorCode.A2A_SCOPE_VIOLATION,
+            error_message=(
+                f"A2A delegation_depth {context.delegation_depth} exceeds cap of "
+                f"{A2A_MAX_DELEGATION_DEPTH}"
+            ),
+        )
+
+    result = verify_schema_offline(
+        schema,
+        signature_b64,
+        domain,
+        tool_id,
+        discovery,
+        revocation,
+        pin_store,
+        canonicalization,
+    )
+    if not result.valid:
+        return result
+
+    if not a2a_allows(context.trusted_domains, domain):
+        return VerificationResult(
+            valid=False,
+            domain=domain,
+            error_code=ErrorCode.A2A_SCOPE_VIOLATION,
+            error_message=(
+                f"Provider domain '{domain}' not in caller's A2A "
+                f"trusted_domains scope"
+            ),
+        )
+
+    return result

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = schemapin
-version = 1.4.0a2
+version = 1.4.0a3
 author = ThirdKey
 author_email = contact@thirdkey.ai
 maintainer = Jascha Wanger

--- a/python/tests/test_a2a.py
+++ b/python/tests/test_a2a.py
@@ -1,0 +1,275 @@
+"""Tests for the v1.4 alpha.3 canonicalization id and A2A context surface."""
+
+from __future__ import annotations
+
+import pytest
+
+from schemapin import (
+    A2A_MAX_DELEGATION_DEPTH,
+    CANONICALIZATION_V1,
+    A2aVerificationContext,
+    ErrorCode,
+    KeyManager,
+    KeyPinStore,
+    SchemaPinCore,
+    SignatureManager,
+    a2a_allows,
+    a2a_intersect,
+    a2a_is_unrestricted,
+    check_canonicalization,
+    verify_schema_for_a2a,
+    verify_schema_offline,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AllowedDomains helpers (mirrors AgentPin v0.3 §4.11 semantics)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestAllowedDomainsHelpers:
+    def test_empty_is_unrestricted(self) -> None:
+        assert a2a_is_unrestricted([])
+        assert a2a_is_unrestricted(None)
+
+    def test_unrestricted_allows_anything(self) -> None:
+        assert a2a_allows([], "literally-anything")
+
+    def test_restricted_filters(self) -> None:
+        ad = ["api.client.com", "*.partner.com"]
+        assert a2a_allows(ad, "api.client.com")
+        assert a2a_allows(ad, "tools.partner.com")
+        assert not a2a_allows(ad, "partner.com")  # *.partner.com excludes bare
+        assert not a2a_allows(ad, "evil.example.com")
+
+    def test_intersect_with_unrestricted_returns_other(self) -> None:
+        assert a2a_intersect([], ["a.com", "b.com"]) == ["a.com", "b.com"]
+        assert a2a_intersect(["a.com", "b.com"], []) == ["a.com", "b.com"]
+
+    def test_intersect_overlap(self) -> None:
+        assert a2a_intersect(["a.com", "b.com", "c.com"], ["b.com", "c.com", "d.com"]) == [
+            "b.com",
+            "c.com",
+        ]
+
+    def test_intersect_empty_overlap_is_unrestricted_per_spec(self) -> None:
+        # AgentPin spec §4.11.4 edge case: disjoint non-empty allow-lists
+        # intersect to []. Under the convention that's "unrestricted".
+        result = a2a_intersect(["a.com"], ["b.com"])
+        assert result == []
+        assert a2a_is_unrestricted(result)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Canonicalization algorithm identifier
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCheckCanonicalization:
+    def test_absent_is_supported(self) -> None:
+        assert check_canonicalization(None) is None
+
+    def test_v1_is_supported(self) -> None:
+        assert check_canonicalization(CANONICALIZATION_V1) is None
+        assert check_canonicalization("schemapin-v1") is None
+
+    def test_unknown_returns_offending_value(self) -> None:
+        assert check_canonicalization("schemapin-v999") == "schemapin-v999"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Verification fixture
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def signed_schema():
+    """Generate a fresh keypair, sign a tiny schema, return everything callers need."""
+    private_key, public_key = KeyManager.generate_keypair()
+    public_pem = KeyManager.export_public_key_pem(public_key)
+    private_pem = KeyManager.export_private_key_pem(private_key)
+    schema = {
+        "name": "calculate_sum",
+        "description": "Calculates the sum of two numbers",
+        "parameters": {"a": "integer", "b": "integer"},
+    }
+    schema_hash = SchemaPinCore.canonicalize_and_hash(schema)
+    signature = SignatureManager.sign_hash(schema_hash, private_key)
+    discovery = {
+        "schema_version": "1.2",
+        "developer_name": "Test Developer",
+        "public_key_pem": public_pem,
+        "revoked_keys": [],
+    }
+    return {
+        "schema": schema,
+        "signature": signature,
+        "discovery": discovery,
+        "private_pem": private_pem,
+        "public_pem": public_pem,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Canonicalization integration into verify_schema_offline
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestVerifySchemaOfflineCanonicalization:
+    def test_absent_canonicalization_accepted(self, signed_schema) -> None:
+        result = verify_schema_offline(
+            signed_schema["schema"],
+            signed_schema["signature"],
+            "example.com",
+            "calculate_sum",
+            signed_schema["discovery"],
+            None,
+            KeyPinStore(),
+        )
+        assert result.valid, result
+
+    def test_v1_canonicalization_accepted(self, signed_schema) -> None:
+        result = verify_schema_offline(
+            signed_schema["schema"],
+            signed_schema["signature"],
+            "example.com",
+            "calculate_sum",
+            signed_schema["discovery"],
+            None,
+            KeyPinStore(),
+            canonicalization=CANONICALIZATION_V1,
+        )
+        assert result.valid
+
+    def test_unknown_canonicalization_rejected(self, signed_schema) -> None:
+        result = verify_schema_offline(
+            signed_schema["schema"],
+            signed_schema["signature"],
+            "example.com",
+            "calculate_sum",
+            signed_schema["discovery"],
+            None,
+            KeyPinStore(),
+            canonicalization="schemapin-v999",
+        )
+        assert not result.valid
+        assert result.error_code == ErrorCode.CANONICALIZATION_UNSUPPORTED
+
+
+# ──────────────────────────────────────────────────────────────────────
+# verify_schema_for_a2a
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _ctx(trusted, depth=0):
+    return A2aVerificationContext(
+        caller_agent_id="urn:agentpin:caller.com:test",
+        delegation_depth=depth,
+        originating_domain="caller.com",
+        trusted_domains=list(trusted),
+    )
+
+
+class TestVerifySchemaForA2A:
+    def test_unrestricted_caller_allows_any_provider(self, signed_schema) -> None:
+        result = verify_schema_for_a2a(
+            signed_schema["schema"],
+            signed_schema["signature"],
+            "example.com",
+            "calculate_sum",
+            signed_schema["discovery"],
+            None,
+            KeyPinStore(),
+            _ctx([]),
+        )
+        assert result.valid, result
+
+    def test_caller_allow_list_includes_provider(self, signed_schema) -> None:
+        result = verify_schema_for_a2a(
+            signed_schema["schema"],
+            signed_schema["signature"],
+            "example.com",
+            "calculate_sum",
+            signed_schema["discovery"],
+            None,
+            KeyPinStore(),
+            _ctx(["example.com", "other.com"]),
+        )
+        assert result.valid
+
+    def test_provider_outside_caller_scope_rejected(self, signed_schema) -> None:
+        result = verify_schema_for_a2a(
+            signed_schema["schema"],
+            signed_schema["signature"],
+            "example.com",
+            "calculate_sum",
+            signed_schema["discovery"],
+            None,
+            KeyPinStore(),
+            _ctx(["other.com"]),
+        )
+        assert not result.valid
+        assert result.error_code == ErrorCode.A2A_SCOPE_VIOLATION
+
+    def test_delegation_depth_cap_enforced(self, signed_schema) -> None:
+        result = verify_schema_for_a2a(
+            signed_schema["schema"],
+            signed_schema["signature"],
+            "example.com",
+            "calculate_sum",
+            signed_schema["discovery"],
+            None,
+            KeyPinStore(),
+            _ctx([], depth=A2A_MAX_DELEGATION_DEPTH + 1),
+        )
+        assert not result.valid
+        assert result.error_code == ErrorCode.A2A_SCOPE_VIOLATION
+
+    def test_underlying_signature_failure_passes_through(self, signed_schema) -> None:
+        result = verify_schema_for_a2a(
+            signed_schema["schema"],
+            "bm90LWEtdmFsaWQtc2lnbmF0dXJl",
+            "example.com",
+            "calculate_sum",
+            signed_schema["discovery"],
+            None,
+            KeyPinStore(),
+            _ctx([]),
+        )
+        assert not result.valid
+        # The cryptographic failure is what surfaces, not A2A_SCOPE_VIOLATION
+        assert result.error_code == ErrorCode.SIGNATURE_INVALID
+
+    def test_canonicalization_unknown_rejected_through_a2a(self, signed_schema) -> None:
+        result = verify_schema_for_a2a(
+            signed_schema["schema"],
+            signed_schema["signature"],
+            "example.com",
+            "calculate_sum",
+            signed_schema["discovery"],
+            None,
+            KeyPinStore(),
+            _ctx([]),
+            canonicalization="schemapin-v999",
+        )
+        assert not result.valid
+        assert result.error_code == ErrorCode.CANONICALIZATION_UNSUPPORTED
+
+    def test_wildcard_provider_in_caller_trusted_list(self, signed_schema) -> None:
+        # *.example.com matches api.example.com via allows() — this is the
+        # primary path, not the intersect-becomes-empty edge case.
+        result = verify_schema_for_a2a(
+            signed_schema["schema"],
+            signed_schema["signature"],
+            "api.example.com",
+            "calculate_sum",
+            {
+                **signed_schema["discovery"],
+            },
+            None,
+            KeyPinStore(),
+            _ctx(["*.example.com"]),
+        )
+        # Note: the signed schema's "domain" param matches the discovery doc's
+        # public key, so signature verification still succeeds here.
+        assert result.valid, result

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "schemapin"
-version = "1.4.0-alpha.2"
+version = "1.4.0-alpha.3"
 dependencies = [
  "async-trait",
  "base64 0.21.7",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schemapin"
-version = "1.4.0-alpha.2"
+version = "1.4.0-alpha.3"
 edition = "2021"
 rust-version = "1.70"
 description = "Cryptographic schema integrity verification for AI tools - Rust implementation"

--- a/rust/src/canonicalize.rs
+++ b/rust/src/canonicalize.rs
@@ -2,6 +2,28 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 
+/// Canonical-algorithm identifier (v1.4) for the sorted-key, no-whitespace,
+/// UTF-8 canonicalization implemented in this module.
+///
+/// Signatures MAY carry a `canonicalization` field naming the algorithm used
+/// to produce the signing input. Absence is equivalent to this identifier
+/// for backward compatibility with v1.3 signatures. Verifiers MUST reject
+/// any other value as `CANONICALIZATION_UNSUPPORTED`.
+pub const CANONICALIZATION_V1: &str = "schemapin-v1";
+
+/// Returns `Ok(())` if `algorithm` names a canonicalization algorithm this
+/// SDK supports. Returns `Err(declared)` with the offending value when it
+/// does not — the caller surfaces this as `ErrorCode::CanonicalizationUnsupported`.
+///
+/// `None` means the field is absent and is equivalent to the default
+/// `schemapin-v1` algorithm (v1.3 backward compatibility).
+pub fn check_canonicalization(algorithm: Option<&str>) -> Result<(), String> {
+    match algorithm {
+        None | Some(CANONICALIZATION_V1) => Ok(()),
+        Some(other) => Err(other.to_string()),
+    }
+}
+
 /// Recursively sort JSON object keys and produce a canonical string.
 ///
 /// - Object keys are sorted lexicographically (BTreeMap guarantees this).

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -81,6 +81,16 @@ pub enum ErrorCode {
     DomainMismatch,
     #[serde(rename = "SCHEMA_CANONICALIZATION_FAILED")]
     SchemaCanonicalizationFailed,
+    /// (v1.4) Signature declared a `canonicalization` algorithm identifier that
+    /// this verifier does not support. Hard failure — verifiers MUST reject
+    /// unknown algorithms rather than silently fall back.
+    #[serde(rename = "CANONICALIZATION_UNSUPPORTED")]
+    CanonicalizationUnsupported,
+    /// (v1.4) A2A scope violation — the tool provider's domain is not in the
+    /// caller's `AllowedDomains` allow-list (under the AgentPin
+    /// empty-list-equals-unrestricted convention).
+    #[serde(rename = "A2A_SCOPE_VIOLATION")]
+    A2aScopeViolation,
 }
 
 impl std::fmt::Display for ErrorCode {
@@ -94,6 +104,8 @@ impl std::fmt::Display for ErrorCode {
             ErrorCode::DiscoveryInvalid => "DISCOVERY_INVALID",
             ErrorCode::DomainMismatch => "DOMAIN_MISMATCH",
             ErrorCode::SchemaCanonicalizationFailed => "SCHEMA_CANONICALIZATION_FAILED",
+            ErrorCode::CanonicalizationUnsupported => "CANONICALIZATION_UNSUPPORTED",
+            ErrorCode::A2aScopeViolation => "A2A_SCOPE_VIOLATION",
         };
         write!(f, "{}", s)
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -80,3 +80,8 @@ pub mod verification;
 
 // New module (v1.4.0): DNS TXT cross-verification
 pub mod dns;
+
+// Re-exports for the v1.4 A2A surface so callers can write
+// `use schemapin::A2aVerificationContext;` without diving into `types::a2a`.
+pub use types::a2a::A2aVerificationContext;
+pub use verification::{verify_schema_for_a2a, A2A_MAX_DELEGATION_DEPTH};

--- a/rust/src/skill.rs
+++ b/rust/src/skill.rs
@@ -33,6 +33,9 @@ use crate::verification::{KeyPinningStatus, VerificationResult};
 /// - `previous_hash` — SHA-256 hash (`sha256:<hex>`) of the *prior* signed version's
 ///   `skill_hash`, forming a hash chain. Use [`verify_chain`] to confirm a new signature
 ///   descends from a specific prior signature.
+/// - `canonicalization` — algorithm identifier naming the canonicalization used to
+///   produce the signing input. Absence is equivalent to `"schemapin-v1"`. Verifiers
+///   MUST reject any other value as `CANONICALIZATION_UNSUPPORTED`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SkillSignature {
     pub schemapin_version: String,
@@ -46,6 +49,8 @@ pub struct SkillSignature {
     pub schema_version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub previous_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub canonicalization: Option<String>,
     pub domain: String,
     pub signer_kid: String,
     pub file_manifest: BTreeMap<String, String>,
@@ -212,6 +217,13 @@ pub struct SignOptions<'a> {
     /// `sha256:<hex>` hash of the *prior* signed version's `skill_hash`, forming a chain.
     /// When set, written to `previous_hash`. Pair with [`verify_chain`] at verify time.
     pub previous_hash: Option<&'a str>,
+    /// Canonicalization algorithm identifier to record in the signature.
+    ///
+    /// When set, written to `canonicalization`. The default (`None`) maps to "absent
+    /// field" on the wire, which v1.3+ verifiers MUST interpret as the implicit
+    /// `schemapin-v1` algorithm. Pass `Some("schemapin-v1")` explicitly to declare
+    /// the algorithm on the wire while staying behavior-equivalent.
+    pub canonicalization: Option<&'a str>,
 }
 
 impl<'a> SignOptions<'a> {
@@ -243,6 +255,17 @@ impl<'a> SignOptions<'a> {
         self.previous_hash = Some(hash);
         self
     }
+
+    /// Declare the canonicalization algorithm identifier on the wire.
+    ///
+    /// Pass [`crate::canonicalize::CANONICALIZATION_V1`] to write the default
+    /// `schemapin-v1` value. Unknown values will be rejected by every v1.4
+    /// verifier that supports this field — there is currently exactly one
+    /// supported algorithm.
+    pub fn with_canonicalization(mut self, algorithm: &'a str) -> Self {
+        self.canonicalization = Some(algorithm);
+        self
+    }
 }
 
 /// Sign a skill directory and write `.schemapin.sig`.
@@ -266,6 +289,7 @@ pub fn sign_skill(
             expires_in: None,
             schema_version: None,
             previous_hash: None,
+            canonicalization: None,
         },
     )
 }
@@ -311,11 +335,14 @@ pub fn sign_skill_with_options(
 
     let schema_version = options.schema_version.map(str::to_string);
     let previous_hash = options.previous_hash.map(str::to_string);
+    let canonicalization = options.canonicalization.map(str::to_string);
 
     // Any v1.4 optional field bumps the version stamp; pure v1.3 sigs stay "1.3"
     // for byte-stable backward compatibility.
-    let uses_v1_4_field =
-        expires_at.is_some() || schema_version.is_some() || previous_hash.is_some();
+    let uses_v1_4_field = expires_at.is_some()
+        || schema_version.is_some()
+        || previous_hash.is_some()
+        || canonicalization.is_some();
     let version = if uses_v1_4_field { "1.4" } else { "1.3" };
 
     let sig_doc = SkillSignature {
@@ -327,6 +354,7 @@ pub fn sign_skill_with_options(
         expires_at,
         schema_version,
         previous_hash,
+        canonicalization,
         domain: domain.to_string(),
         signer_kid: kid,
         file_manifest: manifest,
@@ -367,6 +395,17 @@ pub fn verify_skill_offline(
             }
         },
     };
+
+    // Step 1a (v1.4): Reject unknown canonicalization algorithms before any
+    // crypto work — absent / "schemapin-v1" are equivalent and accepted.
+    if let Err(declared) =
+        crate::canonicalize::check_canonicalization(sig.canonicalization.as_deref())
+    {
+        return VerificationResult::failure(
+            ErrorCode::CanonicalizationUnsupported,
+            &format!("Unsupported canonicalization algorithm: {}", declared),
+        );
+    }
 
     // Step 2: Validate discovery document
     if let Err(e) = validate_well_known_response(discovery) {

--- a/rust/src/types/a2a.rs
+++ b/rust/src/types/a2a.rs
@@ -1,0 +1,211 @@
+//! A2A verification context types (v1.4).
+//!
+//! SchemaPin verifies tool schemas. When a tool invocation crosses an A2A
+//! (Agent-to-Agent) trust boundary, the verifier needs to scope the result
+//! to the intersection of *caller-trusted* domains and the *tool provider's*
+//! domain. This module defines [`A2aVerificationContext`] and the
+//! [`AllowedDomains`] helpers used to compute that intersection.
+//!
+//! ## AllowedDomains convention
+//!
+//! The allow-list semantics mirror AgentPin v0.3 (§4.11 of the AgentPin
+//! technical specification) **exactly**:
+//!
+//! > **An empty `AllowedDomains` list means *unrestricted* (all domains
+//! > trusted).**
+//!
+//! This is the opposite of the naïve set-theoretic interpretation (where an
+//! empty set allows nothing) but matches the existing v1.3 behaviour where
+//! an *omitted* `allowed_domains` field allowed all domains. It lets
+//! callers pass `Vec::new()` to mean "no restriction" without inventing a
+//! sentinel.
+//!
+//! SchemaPin defines these helpers locally rather than depending on the
+//! AgentPin crate — keeping SchemaPin self-contained for users who only
+//! consume tool-integrity, and avoiding a circular trust-stack dependency.
+//! Callers who *do* link both SDKs can pass the result of
+//! `agentpin::AllowedDomains::intersect(...)` into
+//! [`A2aVerificationContext::trusted_domains`] verbatim — the wire and
+//! in-memory shapes are identical.
+
+use serde::{Deserialize, Serialize};
+
+/// Information that scopes a schema verification to an A2A interaction.
+///
+/// Pair with [`crate::verification::verify_schema_for_a2a`] to run the
+/// standard 7-step verification flow with the additional A2A scope check.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct A2aVerificationContext {
+    /// Caller's agent identity (URN-style, matching AgentPin).
+    ///
+    /// Informational only — SchemaPin does not validate the URN shape or
+    /// check it against an external identity provider. The field exists so
+    /// downstream policy engines (Symbiont) can correlate verification
+    /// results with the originating caller.
+    pub caller_agent_id: String,
+
+    /// Depth in the A2A delegation chain. `0` means direct caller.
+    ///
+    /// Verifiers SHOULD reject `delegation_depth > 3` to match the AgentPin
+    /// `max_delegation_depth` cap (AgentPin spec §4.3). The check is
+    /// performed inside [`crate::verification::verify_schema_for_a2a`].
+    pub delegation_depth: u8,
+
+    /// Originating domain of the A2A request. Informational; the scope check
+    /// uses `trusted_domains` ∩ {tool provider domain}, not this field.
+    pub originating_domain: String,
+
+    /// Caller-trusted domains.
+    ///
+    /// Uses the AgentPin convention: **an empty `Vec` means *unrestricted***
+    /// (all domains trusted), not "deny-all". See module-level docs.
+    pub trusted_domains: Vec<String>,
+}
+
+impl A2aVerificationContext {
+    /// Construct a context that places no restriction on which provider
+    /// domains may be verified through.
+    pub fn unrestricted(caller_agent_id: impl Into<String>) -> Self {
+        Self {
+            caller_agent_id: caller_agent_id.into(),
+            delegation_depth: 0,
+            originating_domain: String::new(),
+            trusted_domains: Vec::new(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AllowedDomains helpers
+// ---------------------------------------------------------------------------
+//
+// Spec source of truth: AgentPin technical specification §4.11. This module
+// re-implements the helpers locally rather than linking the AgentPin crate
+// (see module-level docs for rationale). Update both projects in lockstep if
+// the convention ever changes.
+
+/// Returns `true` when `list` is an unrestricted allow-list (empty).
+pub fn is_unrestricted(list: &[String]) -> bool {
+    list.is_empty()
+}
+
+/// Returns `true` when `domain` is permitted under `list`.
+///
+/// An empty `list` allows everything. A non-empty `list` allows the domain
+/// when it exactly matches an entry OR matches one of the entry's wildcard
+/// patterns. Pattern matching follows AgentPin spec §5.5: a leading `*.`
+/// matches any subdomain (e.g. `*.client.com` matches `api.client.com`
+/// but not `client.com` itself).
+pub fn allows(list: &[String], domain: &str) -> bool {
+    if is_unrestricted(list) {
+        return true;
+    }
+    list.iter().any(|pattern| pattern_matches(pattern, domain))
+}
+
+/// Intersection of two allow-lists, honouring the `empty = unrestricted`
+/// convention.
+///
+/// - `unrestricted ∩ X = X`
+/// - `X ∩ unrestricted = X`
+/// - Otherwise: literal set intersection of `lhs` and `rhs` (string equality;
+///   no wildcard expansion). Preserves the order of `lhs`.
+///
+/// An intersection that yields an empty `Vec` from two non-empty inputs is
+/// *re-interpreted as unrestricted* under the same convention. This is the
+/// AgentPin spec §4.11.4 edge case — callers needing to distinguish
+/// "intentionally restricted to nothing" from "no restriction" must track
+/// that distinction outside the allow-list value.
+pub fn intersect(lhs: &[String], rhs: &[String]) -> Vec<String> {
+    if is_unrestricted(lhs) {
+        return rhs.to_vec();
+    }
+    if is_unrestricted(rhs) {
+        return lhs.to_vec();
+    }
+    lhs.iter()
+        .filter(|d| rhs.iter().any(|r| r == *d))
+        .cloned()
+        .collect()
+}
+
+/// Wildcard-aware domain pattern matcher.
+///
+/// `*.example.com` matches `api.example.com` and `a.b.example.com` but NOT
+/// `example.com` itself. Anything without a leading `*.` is a literal
+/// equality check.
+fn pattern_matches(pattern: &str, domain: &str) -> bool {
+    if let Some(suffix) = pattern.strip_prefix("*.") {
+        // Match {anything}.suffix but not bare suffix.
+        if domain.len() <= suffix.len() {
+            return false;
+        }
+        let dot_position = domain.len() - suffix.len() - 1;
+        return domain.ends_with(suffix) && domain.as_bytes().get(dot_position) == Some(&b'.');
+    }
+    pattern == domain
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unrestricted_helpers_round_trip() {
+        let ad: Vec<String> = Vec::new();
+        assert!(is_unrestricted(&ad));
+        assert!(allows(&ad, "anything.example.com"));
+        assert!(allows(&ad, "literally-anything"));
+    }
+
+    #[test]
+    fn restricted_allows_only_listed_domains() {
+        let ad: Vec<String> = vec!["api.client.com".to_string(), "*.partner.com".to_string()];
+        assert!(allows(&ad, "api.client.com"));
+        assert!(allows(&ad, "tools.partner.com"));
+        assert!(allows(&ad, "deep.nested.partner.com"));
+        assert!(!allows(&ad, "partner.com")); // *.partner.com does not match bare partner.com
+        assert!(!allows(&ad, "evil.example.com"));
+    }
+
+    #[test]
+    fn intersect_with_unrestricted_returns_other() {
+        let unrestricted: Vec<String> = Vec::new();
+        let restricted = vec!["a.com".to_string(), "b.com".to_string()];
+        assert_eq!(intersect(&unrestricted, &restricted), restricted);
+        assert_eq!(intersect(&restricted, &unrestricted), restricted);
+    }
+
+    #[test]
+    fn intersect_returns_overlap() {
+        let lhs = vec![
+            "a.com".to_string(),
+            "b.com".to_string(),
+            "c.com".to_string(),
+        ];
+        let rhs = vec![
+            "b.com".to_string(),
+            "c.com".to_string(),
+            "d.com".to_string(),
+        ];
+        assert_eq!(
+            intersect(&lhs, &rhs),
+            vec!["b.com".to_string(), "c.com".to_string()]
+        );
+    }
+
+    #[test]
+    fn intersect_empty_overlap_is_treated_as_unrestricted() {
+        let lhs = vec!["a.com".to_string()];
+        let rhs = vec!["b.com".to_string()];
+        let result = intersect(&lhs, &rhs);
+        assert!(is_unrestricted(&result));
+    }
+
+    #[test]
+    fn pattern_wildcard_does_not_match_bare_domain() {
+        assert!(pattern_matches("*.partner.com", "api.partner.com"));
+        assert!(!pattern_matches("*.partner.com", "partner.com"));
+        assert!(!pattern_matches("*.partner.com", "partnercom"));
+    }
+}

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -1,3 +1,4 @@
+pub mod a2a;
 pub mod bundle;
 pub mod discovery;
 pub mod pinning;

--- a/rust/src/verification.rs
+++ b/rust/src/verification.rs
@@ -155,6 +155,45 @@ pub fn verify_schema_offline(
     revocation: Option<&RevocationDocument>,
     pin_store: &mut KeyPinStore,
 ) -> VerificationResult {
+    verify_schema_offline_with_canonicalization(
+        schema,
+        signature_b64,
+        domain,
+        tool_id,
+        discovery,
+        revocation,
+        pin_store,
+        None,
+    )
+}
+
+/// Verify a schema offline, declaring the canonicalization algorithm used
+/// to produce the signing input (v1.4).
+///
+/// `canonicalization` mirrors the optional `canonicalization` field on
+/// `.schemapin.sig` documents. `None` or `Some("schemapin-v1")` are
+/// equivalent and accepted; any other value fails with
+/// `CANONICALIZATION_UNSUPPORTED`.
+#[allow(clippy::too_many_arguments)]
+pub fn verify_schema_offline_with_canonicalization(
+    schema: &Value,
+    signature_b64: &str,
+    domain: &str,
+    tool_id: &str,
+    discovery: &WellKnownResponse,
+    revocation: Option<&RevocationDocument>,
+    pin_store: &mut KeyPinStore,
+    canonicalization: Option<&str>,
+) -> VerificationResult {
+    // Step 0 (v1.4): Reject unknown canonicalization algorithms before any
+    // discovery / crypto work.
+    if let Err(declared) = crate::canonicalize::check_canonicalization(canonicalization) {
+        return VerificationResult::failure(
+            ErrorCode::CanonicalizationUnsupported,
+            &format!("Unsupported canonicalization algorithm: {}", declared),
+        );
+    }
+
     // Step 1: Validate discovery document
     if let Err(e) = validate_well_known_response(discovery) {
         return VerificationResult::failure(
@@ -326,6 +365,89 @@ pub async fn verify_schema(
         revocation.as_ref(),
         pin_store,
     )
+}
+
+/// Maximum A2A delegation depth allowed by this verifier (v1.4).
+///
+/// Mirrors the AgentPin `max_delegation_depth` cap (AgentPin spec §4.3).
+/// Bumping this on the SchemaPin side without a matching bump on AgentPin
+/// would let SchemaPin accept chains AgentPin would reject — keep in lockstep.
+pub const A2A_MAX_DELEGATION_DEPTH: u8 = 3;
+
+/// Verify a schema in the context of an A2A interaction (v1.4).
+///
+/// Wraps [`verify_schema_offline_with_canonicalization`] with an A2A scope
+/// check:
+///
+/// 1. Reject when `context.delegation_depth > A2A_MAX_DELEGATION_DEPTH`.
+///    Surfaces as `A2A_SCOPE_VIOLATION`.
+/// 2. Run the standard 7-step verification. If it fails, return that result
+///    unchanged.
+/// 3. Compute the effective scope as
+///    `intersect(context.trusted_domains, [domain])` using the AgentPin
+///    empty-list-equals-unrestricted convention (see [`crate::types::a2a`]).
+/// 4. Reject when the resulting scope does not allow `domain`. Surfaces as
+///    `A2A_SCOPE_VIOLATION`.
+///
+/// On success the returned [`VerificationResult`] is the result from step 2
+/// unchanged — A2A context does not modify the cryptographic outcome, only
+/// the policy outcome. Callers wanting to record the A2A context in audit
+/// logs should pair this result with the [`A2aVerificationContext`] they
+/// passed in.
+#[allow(clippy::too_many_arguments)]
+pub fn verify_schema_for_a2a(
+    schema: &Value,
+    signature_b64: &str,
+    domain: &str,
+    tool_id: &str,
+    discovery: &WellKnownResponse,
+    revocation: Option<&RevocationDocument>,
+    pin_store: &mut KeyPinStore,
+    context: &crate::types::a2a::A2aVerificationContext,
+    canonicalization: Option<&str>,
+) -> VerificationResult {
+    // Pre-check: enforce delegation-depth cap before any crypto / I/O work.
+    if context.delegation_depth > A2A_MAX_DELEGATION_DEPTH {
+        return VerificationResult::failure(
+            ErrorCode::A2aScopeViolation,
+            &format!(
+                "A2A delegation_depth {} exceeds cap of {}",
+                context.delegation_depth, A2A_MAX_DELEGATION_DEPTH
+            ),
+        );
+    }
+
+    // Run the standard offline verification first.
+    let result = verify_schema_offline_with_canonicalization(
+        schema,
+        signature_b64,
+        domain,
+        tool_id,
+        discovery,
+        revocation,
+        pin_store,
+        canonicalization,
+    );
+    if !result.valid {
+        return result;
+    }
+
+    // Scope check: does the caller's trusted_domains list permit this
+    // provider? Uses [`crate::types::a2a::allows`] directly so the empty
+    // list `unrestricted` convention is honoured without the
+    // disjoint-intersection edge case that `intersect` exposes (see
+    // [`crate::types::a2a::intersect`] docs).
+    if !crate::types::a2a::allows(&context.trusted_domains, domain) {
+        return VerificationResult::failure(
+            ErrorCode::A2aScopeViolation,
+            &format!(
+                "Provider domain '{}' not in caller's A2A trusted_domains scope",
+                domain
+            ),
+        );
+    }
+
+    result
 }
 
 #[cfg(test)]
@@ -608,5 +730,205 @@ mod tests {
         );
         assert!(!result.valid);
         assert_eq!(result.error_code, Some(ErrorCode::DiscoveryInvalid));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // v1.4 alpha.3: canonicalization algorithm identifier
+    // ─────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_v14_canonicalization_absent_accepted() {
+        let mut f = setup();
+        let result = verify_schema_offline_with_canonicalization(
+            &f.schema,
+            &f.signature,
+            "example.com",
+            "calculate_sum",
+            &f.discovery,
+            None,
+            &mut f.pin_store,
+            None,
+        );
+        assert!(result.valid);
+    }
+
+    #[test]
+    fn test_v14_canonicalization_v1_accepted() {
+        let mut f = setup();
+        let result = verify_schema_offline_with_canonicalization(
+            &f.schema,
+            &f.signature,
+            "example.com",
+            "calculate_sum",
+            &f.discovery,
+            None,
+            &mut f.pin_store,
+            Some(crate::canonicalize::CANONICALIZATION_V1),
+        );
+        assert!(result.valid);
+    }
+
+    #[test]
+    fn test_v14_canonicalization_unknown_rejected() {
+        let mut f = setup();
+        let result = verify_schema_offline_with_canonicalization(
+            &f.schema,
+            &f.signature,
+            "example.com",
+            "calculate_sum",
+            &f.discovery,
+            None,
+            &mut f.pin_store,
+            Some("schemapin-v999"),
+        );
+        assert!(!result.valid);
+        assert_eq!(
+            result.error_code,
+            Some(ErrorCode::CanonicalizationUnsupported)
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // v1.4 alpha.3: A2A verification context
+    // ─────────────────────────────────────────────────────────────────────
+
+    fn a2a_ctx(trusted: &[&str], depth: u8) -> crate::types::a2a::A2aVerificationContext {
+        crate::types::a2a::A2aVerificationContext {
+            caller_agent_id: "urn:agentpin:caller.com:test".to_string(),
+            delegation_depth: depth,
+            originating_domain: "caller.com".to_string(),
+            trusted_domains: trusted.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn test_a2a_unrestricted_caller_allows_any_provider() {
+        let mut f = setup();
+        let result = verify_schema_for_a2a(
+            &f.schema,
+            &f.signature,
+            "example.com",
+            "calculate_sum",
+            &f.discovery,
+            None,
+            &mut f.pin_store,
+            &a2a_ctx(&[], 0),
+            None,
+        );
+        assert!(result.valid, "Expected valid, got: {:?}", result);
+    }
+
+    #[test]
+    fn test_a2a_caller_allow_list_includes_provider() {
+        let mut f = setup();
+        let result = verify_schema_for_a2a(
+            &f.schema,
+            &f.signature,
+            "example.com",
+            "calculate_sum",
+            &f.discovery,
+            None,
+            &mut f.pin_store,
+            &a2a_ctx(&["example.com", "other.com"], 1),
+            None,
+        );
+        assert!(result.valid);
+    }
+
+    #[test]
+    fn test_a2a_provider_outside_caller_scope_rejected() {
+        let mut f = setup();
+        let result = verify_schema_for_a2a(
+            &f.schema,
+            &f.signature,
+            "example.com",
+            "calculate_sum",
+            &f.discovery,
+            None,
+            &mut f.pin_store,
+            &a2a_ctx(&["other.com"], 0),
+            None,
+        );
+        assert!(!result.valid);
+        assert_eq!(result.error_code, Some(ErrorCode::A2aScopeViolation));
+    }
+
+    #[test]
+    fn test_a2a_delegation_depth_cap_enforced() {
+        let mut f = setup();
+        let result = verify_schema_for_a2a(
+            &f.schema,
+            &f.signature,
+            "example.com",
+            "calculate_sum",
+            &f.discovery,
+            None,
+            &mut f.pin_store,
+            &a2a_ctx(&[], 4),
+            None,
+        );
+        assert!(!result.valid);
+        assert_eq!(result.error_code, Some(ErrorCode::A2aScopeViolation));
+    }
+
+    #[test]
+    fn test_a2a_underlying_signature_failure_passes_through() {
+        let mut f = setup();
+        let result = verify_schema_for_a2a(
+            &f.schema,
+            "bm90LWEtdmFsaWQtc2lnbmF0dXJl",
+            "example.com",
+            "calculate_sum",
+            &f.discovery,
+            None,
+            &mut f.pin_store,
+            &a2a_ctx(&[], 0),
+            None,
+        );
+        assert!(!result.valid);
+        // Underlying failure surfaces, not A2aScopeViolation.
+        assert_eq!(result.error_code, Some(ErrorCode::SignatureInvalid));
+    }
+
+    #[test]
+    fn test_a2a_canonicalization_unknown_rejected_through_a2a() {
+        let mut f = setup();
+        let result = verify_schema_for_a2a(
+            &f.schema,
+            &f.signature,
+            "example.com",
+            "calculate_sum",
+            &f.discovery,
+            None,
+            &mut f.pin_store,
+            &a2a_ctx(&[], 0),
+            Some("schemapin-v999"),
+        );
+        assert!(!result.valid);
+        assert_eq!(
+            result.error_code,
+            Some(ErrorCode::CanonicalizationUnsupported)
+        );
+    }
+
+    #[test]
+    fn test_a2a_wildcard_provider_in_caller_trusted_list() {
+        let mut f = setup();
+        let result = verify_schema_for_a2a(
+            &f.schema,
+            &f.signature,
+            "api.example.com",
+            "calculate_sum",
+            &f.discovery,
+            None,
+            &mut f.pin_store,
+            &a2a_ctx(&["*.example.com"], 0),
+            None,
+        );
+        // intersect(["*.example.com"], ["api.example.com"]) uses literal
+        // string equality and returns []; under the spec convention this is
+        // "unrestricted" — provider passes. Documented edge case from the
+        // intersection helper.
+        assert!(result.valid, "got: {:?}", result);
     }
 }


### PR DESCRIPTION
## Summary

Items 4 + 5 of the v1.4 roadmap, shipped together across **all four SDKs** (Rust, JavaScript, Python, Go). Wire-compatible with v1.3 / v1.4 alpha.1 / v1.4 alpha.2; all additions are additive optional fields and parameters.

This is the SchemaPin side of the cross-protocol integration with AgentPin v0.3's `AllowedDomains` typed wrapper — the **AgentPin v0.3.0 release** (2026-05-14) was explicitly tagged as "unblocking SchemaPin v1.4.0 `A2aVerificationContext`," and this PR closes that loop.

## What ships

### Item 4 — Canonicalization Algorithm Identifier

Optional `canonicalization` field on `.schemapin.sig` (and matching parameter on the verifier APIs). Forward-compatibility hook so a future v2.x can swap canonicalization without breaking v1.x signatures.

- Current and only supported value: `"schemapin-v1"`. Absence is equivalent.
- Any other value → hard failure with the new `CANONICALIZATION_UNSUPPORTED` / `canonicalization_unsupported` error code, before any cryptographic work.
- Sign-time: `SignOptions.canonicalization` / `SignOptions::with_canonicalization()` (Rust builder).
- Verifier: `verify_schema_offline_with_canonicalization` (Rust) / optional param on `verifySchemaOffline` (JS, Python) / `VerifySchemaOfflineWithCanonicalization` (Go).

### Item 5 — A2A Verification Context

`A2aVerificationContext` + `verify_schema_for_a2a` wrap the standard 7-step flow with:

1. **Delegation-depth cap** — reject `delegation_depth > 3` (mirrors AgentPin's `max_delegation_depth`).
2. **Standard verification.** If it fails, return that unchanged — A2A scope is NOT a remedy for cryptographic failure.
3. **Scope check** — when `trusted_domains` is non-empty, reject when the provider domain isn't allowed by it (wildcard-aware `*.suffix` matching from AgentPin spec §5.5).

Both rejections surface as `A2A_SCOPE_VIOLATION`. `trusted_domains` uses the AgentPin convention: an empty list means **unrestricted** (all domains trusted), not "deny-all".

`AllowedDomains` helpers (`is_unrestricted` / `allows` / `intersect`) are re-implemented locally in each SDK rather than via a hard dep on the AgentPin SDK — keeps SchemaPin self-contained and avoids a circular trust-stack dependency. Wire shapes are byte-identical so callers linking both packages can pass `agentpin.AllowedDomains.intersect()` results directly into `trusted_domains`.

### Spec + CHANGELOG

- `TECHNICAL_SPECIFICATION.md` header bumped from v1.2 to v1.4 (alpha.3) with new §19 (Canonicalization Algorithm Identifier) and §20 (A2A Verification Context).
- `CHANGELOG.md`: new `[1.4.0-alpha.3]` entry above the alpha.2 entry, documenting all five components.

### Version bumps

All four SDKs to `1.4.0-alpha.3` (Python uses `1.4.0a3` per PEP 440):

- `rust/Cargo.toml`
- `javascript/package.json`
- `python/pyproject.toml` + `python/setup.cfg` + `python/schemapin/__init__.py`
- `go/internal/version/version.go`

## Test plan

- [x] Rust: 133 lib tests pass; `cargo clippy -- -D warnings` clean; `cargo fmt --check` clean.
- [x] JavaScript: 180 tests pass (19 new A2A + canonicalization tests).
- [x] Python: 201 tests pass (19 new A2A + canonicalization tests).
- [x] Go: all packages green; `go vet ./...` clean; `gofmt -l .` empty after the bundled cleanup.
- [x] Implementation correctness: `verify_schema_for_a2a` uses `allows(trusted, domain)` directly (NOT `allows(intersect(trusted, [domain]))`) so the disjoint-allow-list edge case from AgentPin spec §4.11.4 doesn't silently bypass the scope check. There's a dedicated unit test for this in each SDK.

## What's NOT in this PR

Items 6 (A2A trust bundle distribution), 7 (scan-aware signatures), 8 (cross-agent schema cache) of the v1.4 roadmap. Per the scope doc at `docs/superpowers/specs/2026-05-15-v1.4-remaining-items.md` (gitignored, local only), those bundle into `1.4.0-alpha.4` (items 6 + 7) and `1.4.0` final (item 8 + polish).

## Bundled cleanup

Pre-existing `gofmt` drift on `go/pkg/bundle/bundle.go`, `go/pkg/revocation/revocation.go`, `go/pkg/skill/skill.go`, and `go/pkg/skill/skill_test.go` is fixed in this PR (got picked up by `gofmt -w .` during pre-commit verification). Whitespace-only — no behaviour change.