### PR TITLE
v1.4-alpha.4: A2A trust-bundle distribution (all four languages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,59 @@ All notable changes to the SchemaPin project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0-alpha.4] - 2026-06-21
+
+### Added
+
+#### Trust Bundle Distribution for A2A Networks — All Four Languages
+
+Signed trust bundles so they can be exchanged between agents over A2A without
+per-bundle out-of-band trust establishment. Roadmap item 6. All additions are
+optional fields — existing unsigned bundles are unaffected.
+
+- **Wire format**: trust bundles gain four optional top-level fields —
+  `bundle_authority` (`{ kid, public_key_pem }`), `signed_at`, `expires_at`,
+  and `signature` (base64 DER ECDSA P-256). Signing stamps
+  `schemapin_bundle_version` to `"1.4"`.
+- **Signing input**: the signature covers the `schemapin-v1` canonicalization
+  (recursive sorted keys, compact, UTF-8) of the whole bundle with the
+  `signature` field set to `""`. The four SDKs produce byte-identical signing
+  input, so a bundle signed by any SDK verifies in every other (proven by the
+  shared `tests/cross-language/signed_bundle.json` fixture).
+- **`sign_trust_bundle(bundle, private_key_pem, kid, signed_at, expires_at?)`**:
+  derives the authority public key from the private key, stamps metadata, and
+  writes the signature. (Camel/Pascal-cased per language.)
+- **`verify_trust_bundle(bundle, authority_pin_store)`**: requires a signed
+  bundle (else `BUNDLE_UNSIGNED`), rejects past-`expires_at` bundles
+  (`BUNDLE_EXPIRED`), TOFU-pins the authority key by `kid` (mismatch →
+  `KEY_PIN_MISMATCH`), then verifies the signature (`SIGNATURE_INVALID`).
+- **`merge_trust_bundles(bundles)`**: deduplicates discovery and revocation
+  documents by domain, newest source (`signed_at`, else `created_at`) winning.
+  Returns an unsigned merged bundle to be re-signed before redistribution.
+- **`schemapin/trustBundle` JSON-RPC envelope helpers**
+  (`build_trust_bundle_request` / `build_trust_bundle_response` /
+  `parse_trust_bundle_response`) for A2A bundle exchange. The libraries provide
+  the message envelope; transport and the receiving pin-store update are the
+  host application's (e.g. Symbiont's) responsibility.
+- **New error codes**: `BUNDLE_UNSIGNED`, `BUNDLE_EXPIRED`.
+
+### Changed
+
+- All four implementations bumped to `1.4.0-alpha.4` (`1.4.0a4` for Python).
+- **Deviation from the scope doc**: `bundle_authority` carries the authority
+  key as `public_key_pem` (consistent with discovery documents) rather than a
+  JWK. PEM is a plain string, which keeps the cross-language canonical signing
+  input trivially identical; JWK would add a key-serialization surface for
+  cross-SDK drift.
+
+### Notes
+
+- This is item 6 of the v1.4 roadmap. Items 7 (scan-aware signatures) and 8
+  (cross-agent schema cache) were **descoped to v1.5** — they are additive and
+  independent, so deferring them does not block the v1.4.0 GA.
+- Symbiont follow-up: receive `schemapin/trustBundle` over A2A and update the
+  local pin store (filed Symbiont-side).
+
 ## [1.4.0-alpha.3] - 2026-05-16
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # SchemaPin Roadmap
 
-![Version](https://img.shields.io/badge/current-v1.3.0-brightgreen)
-![Next](https://img.shields.io/badge/next-v1.4.0_(planning)-blue)
+![Version](https://img.shields.io/badge/current-v1.4.0--alpha.4-blue)
+![Next](https://img.shields.io/badge/next-v1.4.0_GA-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
 **Cryptographic schema integrity verification for AI tool ecosystems — the trust anchor of the ThirdKey trust stack.**
@@ -18,8 +18,10 @@
 | **1.3.0** | 2026-02 | AgentSkills security — skill folder signing | **Shipped** |
 | **1.4.0-alpha.1** | 2026-04-30 | Signature expiration + DNS TXT cross-verification (all 4 langs) | **Shipped** |
 | **1.4.0-alpha.2** | 2026-05-01 | Schema version binding (`schema_version` + `previous_hash` lineage chain, all 4 langs) | **Shipped** |
-| **1.4.0** | Q2-Q3 2026 | Signature lifecycle, version binding, A2A trust | In progress |
-| **1.5.0** | Q4 2026 | Multi-key endorsement, permissions, advanced revocation | Planning |
+| **1.4.0-alpha.3** | 2026-05-16 | Canonicalization algorithm id + A2A verification context (all 4 langs) | **Shipped** |
+| **1.4.0-alpha.4** | 2026-06-21 | A2A trust-bundle distribution — bundle signing, merge, TOFU, JSON-RPC (all 4 langs) | **Shipped** |
+| **1.4.0** | Q3 2026 | Signature lifecycle, version binding, A2A trust — GA (items 7–8 moved to 1.5) | In progress |
+| **1.5.0** | Q4 2026 | Scan-aware signatures, cross-agent schema cache, multi-key endorsement, permissions, advanced revocation | Planning |
 
 ---
 
@@ -145,7 +147,7 @@ AgentPin already uses `_agentpin.{domain}` TXT records, but SchemaPin doesn't le
 _schemapin.example.com. IN TXT "v=schemapin1; kid=acme-2026-01; fp=sha256:a1b2c3d4..."
 ```
 
-### Canonicalization Algorithm Identifier
+### Canonicalization Algorithm Identifier — **Shipped (alpha.3, all 4 langs)**
 
 The current spec hardcodes the canonicalization algorithm (sorted keys, no whitespace, UTF-8). If the algorithm ever needs to change (and JSON canonicalization is notoriously tricky across languages), there's no way to signal which algorithm was used.
 
@@ -156,7 +158,7 @@ The current spec hardcodes the canonicalization algorithm (sorted keys, no white
 
 Trivial to add now, saves a painful migration later.
 
-### A2A Context for Schema Verification
+### A2A Context for Schema Verification — **Shipped (alpha.3, all 4 langs)**
 
 When agents collaborate via A2A (Agent-to-Agent), tool schemas cross trust boundaries. SchemaPin v1.4.0 ensures that tool integrity verification extends seamlessly into A2A networks — every tool invoked through an A2A bridge is verified against its provider's signed schema.
 
@@ -167,16 +169,21 @@ When agents collaborate via A2A (Agent-to-Agent), tool schemas cross trust bound
 | Domain scoping | Accept optional trusted domains as `Vec<String>`, matching the `AllowedDomains` type exported by AgentPin v0.3.0 (extracted from `AgentDeclaration.constraints`). Empty list means no domain restriction. |
 | Intersection check | Scope verification to intersection of caller's allowed domains and tool provider's domain |
 
-### Trust Bundle Distribution for A2A Networks
+### Trust Bundle Distribution for A2A Networks — **Shipped (alpha.4, all 4 langs)**
 
 | Item | Details |
 |------|---------|
-| Bundle signing | Sign trust bundles with a bundle authority key |
+| Bundle signing | Sign trust bundles with a bundle authority key (ECDSA P-256 over `schemapin-v1` canonical bytes) |
 | `merge_trust_bundles()` | Combine bundles from multiple sources with deduplication (newest wins) |
-| TOFU for bundles | TOFU pinning for bundle authority keys |
-| JSON-RPC method | `schemapin/trustBundle` for A2A bundle exchange |
+| TOFU for bundles | TOFU pinning for bundle authority keys, keyed by `kid` |
+| JSON-RPC method | `schemapin/trustBundle` envelope helpers for A2A bundle exchange |
 
-### Scan-Aware Signatures
+Bundle authority key carried as `public_key_pem` (consistent with discovery docs) rather than JWK — see the alpha.4 CHANGELOG for rationale.
+
+### Scan-Aware Signatures — **Moved to v1.5.0**
+
+> Descoped from v1.4.0 GA (2026-06-21). Additive and independent of the rest of
+> v1.4, so deferring it does not block GA. Spec below is retained as the v1.5 plan.
 
 Right now scanning and signing are somewhat independent in the Symbiont/SchemaPin workflow. Making the scan result part of the signature metadata closes this gap — a skill signed with `scan_passed: true` at signing time, with the scanner version and ruleset hash recorded, tells verifiers not just that the content is authentic but that it passed security review at a specific rule version.
 
@@ -200,7 +207,10 @@ Right now scanning and signing are somewhat independent in the Symbiont/SchemaPi
 
 This is fully optional and backward compatible — v1.3 verifiers ignore the new fields.
 
-### Cross-Agent Tool Schema Caching
+### Cross-Agent Tool Schema Caching — **Moved to v1.5.0**
+
+> Descoped from v1.4.0 GA (2026-06-21). A local in-memory cache helper with no
+> wire-format impact; deferring it does not block GA. Spec below is the v1.5 plan.
 
 | Item | Details |
 |------|---------|
@@ -215,6 +225,11 @@ All four language implementations (Rust, JavaScript, Python, Go) receive matchin
 ---
 
 ## v1.5.0 — Multi-Key Endorsement, Permissions & Advanced Revocation (Q4 2026)
+
+**Carried over from v1.4 (descoped 2026-06-21):** Scan-Aware Signatures and
+Cross-Agent Tool Schema Caching. Both are additive and independent of the v1.4
+trust surface, so they ship in v1.5 rather than blocking the v1.4.0 GA. Their
+full specs live in the v1.4 section above (marked "Moved to v1.5.0").
 
 ### Multi-Key / Organizational Endorsement
 
@@ -324,4 +339,4 @@ We welcome input on roadmap priorities:
 
 ---
 
-*Last updated: 2026-05-01 (v1.4.0-alpha.2 — schema version binding across all four language implementations)*
+*Last updated: 2026-06-21 (v1.4.0-alpha.4 — A2A trust-bundle distribution across all four language implementations; items 7–8 descoped to v1.5.0)*

--- a/TECHNICAL_SPECIFICATION.md
+++ b/TECHNICAL_SPECIFICATION.md
@@ -588,3 +588,50 @@ Implementations SHOULD copy these helpers from this section rather than taking a
 - v1.3 verifiers do not know about A2A context — they have no `verify_schema_for_a2a` entry point. Callers integrating with v1.3 verifiers fall back to the standard `verify_schema_offline` flow without scope enforcement.
 - The `A2A_SCOPE_VIOLATION` error code is new in v1.4. Older verifiers cannot emit it.
 - All v1.4 alpha.3 additions are additive — they introduce no changes to the signature on the wire (the new error code lives only in verifier output) so v1.4 alpha.1 / alpha.2 signatures verify identically under alpha.3 verifiers.
+
+### **21. Trust Bundle Distribution (v1.4)**
+
+#### **21.1. Purpose**
+
+Allow a **bundle authority** to sign a trust bundle so it can be exchanged between agents over A2A without per-bundle out-of-band trust establishment. The receiving verifier authenticates the bundle and TOFU-pins the authority key by `kid`, the same trust model used for tool signing keys. All fields are optional and additive — an unsigned bundle is unchanged from v1.2/v1.3.
+
+#### **21.2. Wire Format**
+
+A signed trust bundle adds four OPTIONAL top-level fields:
+
+```json
+{
+  "schemapin_bundle_version": "1.4",
+  "documents": [ "..." ],
+  "revocations": [ "..." ],
+  "bundle_authority": {
+    "kid": "schemapin-bundle-authority-2026",
+    "public_key_pem": "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----\n"
+  },
+  "signed_at": "2026-05-15T00:00:00Z",
+  "expires_at": "2099-01-01T00:00:00Z",
+  "signature": "<base64 DER ECDSA P-256>"
+}
+```
+
+The authority public key is carried as `public_key_pem` (consistent with discovery documents), making the bundle self-verifying. Signing sets `schemapin_bundle_version` to `"1.4"`.
+
+#### **21.3. Signing Input**
+
+The signature covers the `schemapin-v1` canonicalization (§19; recursive sorted keys, compact, UTF-8) of the entire bundle object with the `signature` field set to the empty string `""`. All four SDKs MUST produce the identical byte string so a bundle signed by any SDK verifies in every other.
+
+#### **21.4. Operations**
+
+- `sign_trust_bundle(bundle, private_key_pem, kid, signed_at, expires_at?)` — derive the authority public key, stamp `bundle_authority` / `signed_at` / `expires_at`, and write the signature.
+- `verify_trust_bundle(bundle, authority_pin_store)`:
+  1. Require `bundle_authority` and `signature` — else `BUNDLE_UNSIGNED`.
+  2. Reject when `expires_at` is present and in the past or unparseable — `BUNDLE_EXPIRED`.
+  3. TOFU-pin the authority key fingerprint by `kid`; a different key under a pinned `kid` is `KEY_PIN_MISMATCH`.
+  4. Verify the signature over the canonical bytes — failure is `SIGNATURE_INVALID`.
+- `merge_trust_bundles(bundles)` — deduplicate `documents` and `revocations` by domain, the newer source (`signed_at`, else `created_at`) winning. Returns an UNSIGNED bundle to be re-signed before redistribution.
+- `schemapin/trustBundle` JSON-RPC envelope helpers — `build_trust_bundle_request` / `build_trust_bundle_response` / `parse_trust_bundle_response`. The libraries define the message envelope; transport and the receiving pin-store update are the host application's responsibility.
+
+#### **21.5. Backward Compatibility**
+
+- Unsigned bundles omit all four fields and are byte-identical to pre-v1.4 bundles; existing resolvers ignore the new fields.
+- The `BUNDLE_UNSIGNED` and `BUNDLE_EXPIRED` error codes are new in v1.4.

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,6 +80,7 @@ All four implementations use identical crypto (ECDSA P-256 + SHA-256) — cross-
 | [Signature Expiration](signature-expiration.md) | `expires_at` field for degraded-not-failed verification (v1.4-alpha, all 4 languages) |
 | [DNS TXT Cross-Verification](dns-txt.md) | Second-channel `_schemapin.{domain}` lookups (v1.4-alpha, all 4 languages) |
 | [Schema Version Binding](schema-version-binding.md) | `schema_version` + `previous_hash` lineage chain to defend against rug-pull substitutions (v1.4-alpha, all 4 languages) |
+| [Trust Bundle Distribution](trust-bundle-distribution.md) | Sign, verify, and merge trust bundles for safe A2A exchange (v1.4-alpha, all 4 languages) |
 | [Deployment](deployment.md) | Serve `.well-known` endpoints in production |
 | [Troubleshooting](troubleshooting.md) | Common issues and solutions |
 

--- a/docs/trust-bundle-distribution.md
+++ b/docs/trust-bundle-distribution.md
@@ -1,0 +1,103 @@
+# Trust Bundle Distribution for A2A Networks
+
+> **Status:** v1.4.0-alpha.4 — implemented in **Rust, Python, JavaScript, and Go**. A bundle signed by any one SDK verifies in every other (proven by the shared `tests/cross-language/signed_bundle.json` fixture).
+
+A [trust bundle](trust-bundles.md) pre-packages discovery and revocation documents for offline verification. Until v1.4 a bundle had no authenticity of its own — you had to trust however it reached you. That is fine for a bundle you build and ship yourself, but not for one an agent hands to another agent over A2A.
+
+v1.4 lets a **bundle authority** sign a trust bundle so it can be exchanged between agents without per-bundle out-of-band trust establishment. The receiving agent verifies the signature and TOFU-pins the authority key by `kid`, exactly as it would pin a tool's signing key.
+
+All additions are optional fields — an unsigned bundle is byte-for-byte what it was before v1.4, and v1.2/v1.3 consumers ignore the new fields.
+
+---
+
+## Wire format
+
+A signed bundle gains four optional top-level fields:
+
+```json
+{
+  "schemapin_bundle_version": "1.4",
+  "created_at": "2026-05-15T00:00:00Z",
+  "documents": [ /* ... */ ],
+  "revocations": [ /* ... */ ],
+  "bundle_authority": {
+    "kid": "schemapin-bundle-authority-2026",
+    "public_key_pem": "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----\n"
+  },
+  "signed_at": "2026-05-15T00:00:00Z",
+  "expires_at": "2099-01-01T00:00:00Z",
+  "signature": "MEUCIQ..."
+}
+```
+
+- **`bundle_authority`** — the authority that signed the bundle. The public key is carried as `public_key_pem` (consistent with discovery documents), so the bundle is self-verifying.
+- **`signed_at`** / **`expires_at`** — RFC 3339 timestamps. `expires_at` is optional even on a signed bundle; when present and past, verification fails with `BUNDLE_EXPIRED`.
+- **`signature`** — base64 DER ECDSA P-256 signature.
+
+Signing stamps `schemapin_bundle_version` to `"1.4"`.
+
+### Signing input
+
+The signature covers the **`schemapin-v1` canonicalization** (recursive sorted keys, compact separators, UTF-8) of the entire bundle object with the `signature` field set to the empty string `""`. This is the same canonicalization used for schema and skill signing, so all four SDKs produce the identical byte string and cross-verify.
+
+---
+
+## Operations
+
+| Operation | Purpose |
+|-----------|---------|
+| `sign_trust_bundle(bundle, private_key_pem, kid, signed_at, expires_at?)` | Stamp authority metadata and write the signature. Derives the authority public key from the private key. |
+| `verify_trust_bundle(bundle, authority_pin_store)` | Verify the signature, reject expired bundles, and TOFU-pin the authority key by `kid`. |
+| `merge_trust_bundles(bundles)` | Combine bundles from multiple sources, deduplicating by domain (newest wins). Returns an **unsigned** bundle to re-sign before redistribution. |
+| `build_trust_bundle_request` / `build_trust_bundle_response` / `parse_trust_bundle_response` | `schemapin/trustBundle` JSON-RPC envelope helpers for A2A exchange. |
+
+(Function names are camel/Pascal-cased per language — e.g. `signTrustBundle` in JS, `SignTrustBundle` in Go.)
+
+### Verification steps
+
+`verify_trust_bundle` runs:
+
+1. Require `bundle_authority` and `signature` — else `BUNDLE_UNSIGNED`.
+2. If `expires_at` is present and in the past (or unparseable) — `BUNDLE_EXPIRED`.
+3. TOFU-pin the authority key fingerprint by `kid`. A different key reusing a pinned `kid` — an impersonation attempt — fails with `KEY_PIN_MISMATCH`.
+4. Verify the signature over the canonical bytes — failure is `SIGNATURE_INVALID`.
+
+---
+
+## Example (Rust)
+
+```rust
+use schemapin::bundle::{sign_trust_bundle, verify_trust_bundle, merge_trust_bundles};
+use schemapin::pinning::KeyPinStore;
+
+// Authority signs a bundle for distribution.
+let signed = sign_trust_bundle(
+    &bundle,
+    &authority_private_pem,
+    "schemapin-bundle-authority-2026",
+    "2026-05-15T00:00:00Z",
+    Some("2026-08-15T00:00:00Z"),
+)?;
+
+// A receiving agent verifies it and TOFU-pins the authority.
+let mut authorities = KeyPinStore::new();
+verify_trust_bundle(&signed, &mut authorities)?;
+
+// Combine bundles from several sources before re-signing.
+let merged = merge_trust_bundles(&[signed, other_signed]);
+```
+
+The JSON-RPC helpers produce the `schemapin/trustBundle` message envelope; the
+transport and the receiving pin-store update are the host application's
+responsibility (e.g. a Symbiont coordinator receiving the message over A2A).
+
+---
+
+## Key rotation
+
+The bundle authority is a long-lived signing key. To rotate it, sign new
+bundles under a new `kid` and distribute the new authority public key through
+the same channel you bootstrap any first-use key. Verifiers TOFU-pin per `kid`,
+so a new `kid` is a first-use pin, not a mismatch.
+
+See [Technical specification](https://github.com/ThirdKeyAI/SchemaPin/blob/main/TECHNICAL_SPECIFICATION.md) for the normative definition.

--- a/go/internal/version/version.go
+++ b/go/internal/version/version.go
@@ -2,7 +2,7 @@
 package version
 
 // Version is set at build time via ldflags
-var Version = "1.4.0-alpha.3"
+var Version = "1.4.0-alpha.4"
 
 // GetVersion returns the current version string
 func GetVersion() string {

--- a/go/pkg/bundle/authority_pin_store.go
+++ b/go/pkg/bundle/authority_pin_store.go
@@ -1,0 +1,59 @@
+package bundle
+
+// In-memory TOFU pin store for bundle authorities (v1.4).
+//
+// Mirrors the Rust schemapin::pinning::KeyPinStore semantics used by
+// verify_trust_bundle: authorities are pinned by a composite "kid@domain" key
+// (domain is always BundleAuthorityPinDomain here), trust-on-first-use, and a
+// later fingerprint that does not match a pinned one is reported as Changed.
+//
+// This is deliberately a lightweight in-memory store rather than the BoltDB
+// KeyPinning type so bundle distribution stays self-contained and easy to embed
+// (matching the Rust reference, which uses an in-memory store for authorities).
+
+import "fmt"
+
+// PinningResult is the outcome of checking a key fingerprint against the store.
+type PinningResult int
+
+const (
+	// PinningResultFirstUse means this kid@domain had not been seen before and
+	// the fingerprint has now been pinned (TOFU).
+	PinningResultFirstUse PinningResult = iota
+	// PinningResultMatched means the fingerprint matches a previously pinned key.
+	PinningResultMatched
+	// PinningResultChanged means kid@domain was seen before but the fingerprint
+	// does not match any pinned key (impersonation / rotation).
+	PinningResultChanged
+)
+
+// AuthorityPinStore is an in-memory TOFU store keyed by "kid@domain".
+type AuthorityPinStore struct {
+	fingerprints map[string]string
+}
+
+// NewAuthorityPinStore creates an empty authority pin store.
+func NewAuthorityPinStore() *AuthorityPinStore {
+	return &AuthorityPinStore{fingerprints: map[string]string{}}
+}
+
+func compositeKey(kid, domain string) string {
+	return fmt.Sprintf("%s@%s", kid, domain)
+}
+
+// CheckAndPin checks a fingerprint against the store. The first time a kid@domain
+// is seen the fingerprint is pinned and PinningResultFirstUse is returned;
+// thereafter a matching fingerprint returns PinningResultMatched and a differing
+// one returns PinningResultChanged.
+func (s *AuthorityPinStore) CheckAndPin(kid, domain, fingerprint string) PinningResult {
+	key := compositeKey(kid, domain)
+	pinned, ok := s.fingerprints[key]
+	if !ok {
+		s.fingerprints[key] = fingerprint
+		return PinningResultFirstUse
+	}
+	if pinned == fingerprint {
+		return PinningResultMatched
+	}
+	return PinningResultChanged
+}

--- a/go/pkg/bundle/bundle.go
+++ b/go/pkg/bundle/bundle.go
@@ -57,12 +57,37 @@ func (b *BundledDiscovery) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(wellKnownData, &b.WellKnown)
 }
 
+// BundleAuthority (v1.4) identifies and carries the public key of the authority
+// that signed a trust bundle. TOFU-pinned by Kid on first use (see
+// VerifyTrustBundle).
+type BundleAuthority struct {
+	Kid          string `json:"kid"`
+	PublicKeyPEM string `json:"public_key_pem"`
+}
+
 // SchemaPinTrustBundle holds discovery documents and revocations for offline use.
+//
+// v1.4 adds optional distribution fields (BundleAuthority, SignedAt, ExpiresAt,
+// Signature) so bundles can be signed by a bundle authority and safely exchanged
+// between agents over A2A. See the SignTrustBundle / VerifyTrustBundle /
+// MergeTrustBundles operations in distribution.go.
 type SchemaPinTrustBundle struct {
 	SchemapinBundleVersion string                          `json:"schemapin_bundle_version"`
 	CreatedAt              string                          `json:"created_at"`
 	Documents              []BundledDiscovery              `json:"documents"`
 	Revocations            []revocation.RevocationDocument `json:"revocations"`
+	// BundleAuthority (v1.4) is the authority that signed this bundle. Present
+	// on signed bundles.
+	BundleAuthority *BundleAuthority `json:"bundle_authority,omitempty"`
+	// SignedAt (v1.4) is the RFC 3339 timestamp the bundle was signed.
+	SignedAt string `json:"signed_at,omitempty"`
+	// ExpiresAt (v1.4) is an optional RFC 3339 expiry; verifiers reject the
+	// bundle past this.
+	ExpiresAt string `json:"expires_at,omitempty"`
+	// Signature (v1.4) is the base64 DER ECDSA P-256 signature over the
+	// canonical bundle bytes (schemapin-v1 canonicalization with this field set
+	// to "").
+	Signature string `json:"signature,omitempty"`
 }
 
 // NewTrustBundle creates a new empty trust bundle.

--- a/go/pkg/bundle/distribution.go
+++ b/go/pkg/bundle/distribution.go
@@ -1,0 +1,425 @@
+package bundle
+
+// (v1.4) Trust-bundle distribution for A2A networks.
+//
+// Lets a bundle authority sign a SchemaPinTrustBundle so it can be exchanged
+// between agents over A2A without per-bundle out-of-band trust establishment.
+// Provides:
+//
+//   - SignTrustBundle / VerifyTrustBundle — ECDSA P-256 over the canonical
+//     bundle bytes, with TOFU pinning of the authority key by kid.
+//   - MergeTrustBundles — combine bundles from multiple sources, newest entry
+//     wins per domain.
+//   - BuildTrustBundleRequest / BuildTrustBundleResponse /
+//     ParseTrustBundleResponse — the schemapin/trustBundle JSON-RPC envelope
+//     for A2A bundle exchange.
+//
+// # Signing input
+//
+// The signature covers the schemapin-v1 canonicalization (recursive sorted
+// keys, compact, UTF-8) of the entire bundle object with the signature field
+// set to the empty string "". All four SDKs build the identical byte string,
+// so a bundle signed by any SDK verifies in every other.
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/ThirdKeyAi/schemapin/go/pkg/crypto"
+	"github.com/ThirdKeyAi/schemapin/go/pkg/revocation"
+)
+
+// ErrorCode mirrors ErrorCode for the bundle-distribution error
+// surface. The values are kept identical to the verification package so callers
+// can compare across both. The bundle package defines them locally rather than
+// importing verification because verification -> resolver -> bundle forms an
+// import cycle.
+type ErrorCode = string
+
+const (
+	// ErrBundleUnsigned (v1.4) — a bundle was passed to VerifyTrustBundle
+	// without a bundle_authority / signature pair.
+	ErrBundleUnsigned ErrorCode = "bundle_unsigned"
+	// ErrBundleExpired (v1.4) — a signed bundle's expires_at is in the past
+	// (or unparseable).
+	ErrBundleExpired ErrorCode = "bundle_expired"
+	// ErrKeyPinMismatch — the bundle authority's key changed since first pin.
+	ErrKeyPinMismatch ErrorCode = "key_pin_mismatch"
+	// ErrSignatureInvalid — the bundle signature does not verify.
+	ErrSignatureInvalid ErrorCode = "signature_invalid"
+	// ErrDiscoveryInvalid — a JSON-RPC response was missing result.bundle.
+	ErrDiscoveryInvalid ErrorCode = "discovery_invalid"
+)
+
+// BundleVersionSigned is the bundle-distribution wire format version stamped on
+// signed bundles.
+const BundleVersionSigned = "1.4"
+
+// BundleAuthorityPinDomain is the sentinel "domain" used to key bundle-authority
+// pins in an AuthorityPinStore. Authorities are pinned by kid, independent of
+// any tool domain.
+const BundleAuthorityPinDomain = "_bundle_authority"
+
+// BundleError is a structured verification error carrying a stable ErrorCode,
+// mirroring the Rust Error::Verification variant.
+type BundleError struct {
+	Code    ErrorCode
+	Message string
+}
+
+func (e *BundleError) Error() string {
+	return fmt.Sprintf("verification failed: %s: %s", e.Code, e.Message)
+}
+
+func newBundleError(code ErrorCode, msg string) *BundleError {
+	return &BundleError{Code: code, Message: msg}
+}
+
+// canonicalizeValue recursively sorts object keys and marshals to compact JSON
+// with HTML escaping disabled, matching the Rust serde_json output used by
+// canonicalize_schema. HTML escaping MUST be off so that '<', '>' and '&' are
+// emitted literally (Go's encoding/json escapes them to \u00xx by default,
+// which would diverge from every other SDK).
+func canonicalizeValue(v interface{}) (string, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return "", err
+	}
+	// json.Encoder appends a trailing newline; trim it.
+	return string(bytes.TrimRight(buf.Bytes(), "\n")), nil
+}
+
+// signingBytes builds the canonical bytes that a bundle's signature covers: the
+// bundle with its signature field forced to "", schemapin-v1-canonicalized.
+//
+// The bundle is first marshaled through marshalBundleForSigning (which mirrors
+// the Rust serde output field-for-field) so absent optional fields are omitted
+// and always-present fields like revoked_keys / revocations are emitted even
+// when empty, then re-parsed into a generic map so Go's encoder sorts every
+// object key recursively.
+func signingBytes(b *SchemaPinTrustBundle) (string, error) {
+	raw, err := marshalBundleForSigning(b)
+	if err != nil {
+		return "", err
+	}
+	var generic map[string]interface{}
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		return "", err
+	}
+	generic["signature"] = ""
+	return canonicalizeValue(generic)
+}
+
+// marshalBundleForSigning serializes a bundle into the canonical wire shape used
+// by all SDKs. It deliberately does NOT reuse BundledDiscovery.MarshalJSON
+// (which omits empty revoked_keys) because the cross-language signing input
+// always emits revoked_keys / revocations even when empty, matching the Rust
+// serde representation.
+func marshalBundleForSigning(b *SchemaPinTrustBundle) ([]byte, error) {
+	m := map[string]interface{}{
+		"schemapin_bundle_version": b.SchemapinBundleVersion,
+		"created_at":               b.CreatedAt,
+		"documents":                marshalDocuments(b.Documents),
+		"revocations":              marshalRevocations(b.Revocations),
+	}
+	if b.BundleAuthority != nil {
+		m["bundle_authority"] = map[string]interface{}{
+			"kid":            b.BundleAuthority.Kid,
+			"public_key_pem": b.BundleAuthority.PublicKeyPEM,
+		}
+	}
+	if b.SignedAt != "" {
+		m["signed_at"] = b.SignedAt
+	}
+	if b.ExpiresAt != "" {
+		m["expires_at"] = b.ExpiresAt
+	}
+	if b.Signature != "" {
+		m["signature"] = b.Signature
+	}
+	return json.Marshal(m)
+}
+
+// marshalDocuments mirrors the Rust WellKnownResponse serde output:
+// developer_name / contact / revocation_endpoint are omitted when empty, but
+// revoked_keys is always present (possibly []).
+func marshalDocuments(docs []BundledDiscovery) []interface{} {
+	out := make([]interface{}, 0, len(docs))
+	for _, d := range docs {
+		m := map[string]interface{}{
+			"domain":         d.Domain,
+			"schema_version": d.WellKnown.SchemaVersion,
+			"public_key_pem": d.WellKnown.PublicKeyPEM,
+		}
+		if d.WellKnown.DeveloperName != "" {
+			m["developer_name"] = d.WellKnown.DeveloperName
+		}
+		rk := d.WellKnown.RevokedKeys
+		if rk == nil {
+			rk = []string{}
+		}
+		m["revoked_keys"] = rk
+		if d.WellKnown.Contact != "" {
+			m["contact"] = d.WellKnown.Contact
+		}
+		if d.WellKnown.RevocationEndpoint != "" {
+			m["revocation_endpoint"] = d.WellKnown.RevocationEndpoint
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// marshalRevocations serializes revocation documents preserving the always-
+// present revoked_keys array so empty slices serialize as [] not null.
+func marshalRevocations(revs []revocation.RevocationDocument) []interface{} {
+	out := make([]interface{}, 0, len(revs))
+	for _, r := range revs {
+		keys := make([]interface{}, 0, len(r.RevokedKeys))
+		for _, k := range r.RevokedKeys {
+			keys = append(keys, map[string]interface{}{
+				"fingerprint": k.Fingerprint,
+				"revoked_at":  k.RevokedAt,
+				"reason":      string(k.Reason),
+			})
+		}
+		out = append(out, map[string]interface{}{
+			"schemapin_version": r.SchemapinVersion,
+			"domain":            r.Domain,
+			"updated_at":        r.UpdatedAt,
+			"revoked_keys":      keys,
+		})
+	}
+	return out
+}
+
+// SignTrustBundle signs a trust bundle with a bundle-authority key.
+//
+// Stamps bundle_authority (derived public key + kid),
+// schemapin_bundle_version = "1.4", signed_at, and optional expires_at, then
+// writes the base64 DER ECDSA P-256 signature. signedAt / expiresAt are
+// caller-supplied RFC 3339 strings (kept out of the core so signing is
+// deterministic and cross-language testable); pass an empty expiresAt to omit
+// it.
+func SignTrustBundle(b *SchemaPinTrustBundle, privateKeyPEM, kid, signedAt, expiresAt string) (*SchemaPinTrustBundle, error) {
+	km := crypto.NewKeyManager()
+	priv, err := km.LoadPrivateKeyPEM(privateKeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load private key: %w", err)
+	}
+	publicKeyPEM, err := km.ExportPublicKeyPEM(&priv.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to export public key: %w", err)
+	}
+
+	signed := b.clone()
+	signed.SchemapinBundleVersion = BundleVersionSigned
+	signed.BundleAuthority = &BundleAuthority{Kid: kid, PublicKeyPEM: publicKeyPEM}
+	signed.SignedAt = signedAt
+	signed.ExpiresAt = expiresAt
+	signed.Signature = ""
+
+	canonical, err := signingBytes(signed)
+	if err != nil {
+		return nil, err
+	}
+
+	hash := sha256.Sum256([]byte(canonical))
+	sm := crypto.NewSignatureManager()
+	sig, err := sm.SignHash(hash[:], priv)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign bundle: %w", err)
+	}
+	signed.Signature = sig
+	return signed, nil
+}
+
+// VerifyTrustBundle verifies a signed trust bundle and TOFU-pins its authority
+// key by kid.
+//
+// Steps: require bundle_authority + signature (else ErrBundleUnsigned); reject
+// when expires_at is in the past or unparseable (ErrBundleExpired); TOFU-pin
+// the authority's key fingerprint by kid (mismatch -> ErrKeyPinMismatch);
+// verify the signature over the canonical bytes (failure -> ErrSignatureInvalid).
+//
+// On a verification failure the returned error is a *BundleError whose Code is
+// the relevant ErrorCode.
+func VerifyTrustBundle(b *SchemaPinTrustBundle, authorityPinStore *AuthorityPinStore) error {
+	if b.BundleAuthority == nil {
+		return newBundleError(ErrBundleUnsigned, "trust bundle has no bundle_authority")
+	}
+	if b.Signature == "" {
+		return newBundleError(ErrBundleUnsigned, "trust bundle has no signature")
+	}
+
+	if b.ExpiresAt != "" {
+		exp, err := time.Parse(time.RFC3339, b.ExpiresAt)
+		if err != nil {
+			return newBundleError(ErrBundleExpired,
+				fmt.Sprintf("unparseable expires_at '%s': %v", b.ExpiresAt, err))
+		}
+		if time.Now().After(exp) {
+			return newBundleError(ErrBundleExpired,
+				fmt.Sprintf("trust bundle expired at %s", b.ExpiresAt))
+		}
+	}
+
+	km := crypto.NewKeyManager()
+	fingerprint, err := km.CalculateKeyFingerprintFromPEM(b.BundleAuthority.PublicKeyPEM)
+	if err != nil {
+		return fmt.Errorf("failed to fingerprint authority key: %w", err)
+	}
+	if authorityPinStore.CheckAndPin(b.BundleAuthority.Kid, BundleAuthorityPinDomain, fingerprint) == PinningResultChanged {
+		return newBundleError(ErrKeyPinMismatch,
+			fmt.Sprintf("bundle authority key for kid '%s' has changed since last pinned", b.BundleAuthority.Kid))
+	}
+
+	pub, err := km.LoadPublicKeyPEM(b.BundleAuthority.PublicKeyPEM)
+	if err != nil {
+		return fmt.Errorf("failed to load authority public key: %w", err)
+	}
+
+	canonical, err := signingBytes(b)
+	if err != nil {
+		return err
+	}
+	hash := sha256.Sum256([]byte(canonical))
+	sm := crypto.NewSignatureManager()
+	if !sm.VerifySignature(hash[:], b.Signature, pub) {
+		return newBundleError(ErrSignatureInvalid, "trust bundle signature does not verify")
+	}
+	return nil
+}
+
+// MergeTrustBundles merges trust bundles, deduplicating discovery + revocation
+// documents by domain. When two bundles carry the same domain, the entry from
+// the bundle with the newer timestamp (signed_at, else created_at) wins.
+//
+// The result is an unsigned bundle (a merge cannot carry a single authority's
+// signature) stamped schemapin_bundle_version = "1.4" with created_at set to
+// the newest source timestamp, sorted by domain. Re-sign it with
+// SignTrustBundle before redistribution.
+func MergeTrustBundles(bundles []*SchemaPinTrustBundle) *SchemaPinTrustBundle {
+	type docEntry struct {
+		ts  string
+		doc BundledDiscovery
+	}
+	type revEntry struct {
+		ts  string
+		rev revocation.RevocationDocument
+	}
+
+	docs := map[string]docEntry{}
+	revs := map[string]revEntry{}
+	newestTS := ""
+
+	for _, b := range bundles {
+		ts := b.SignedAt
+		if ts == "" {
+			ts = b.CreatedAt
+		}
+		if ts > newestTS {
+			newestTS = ts
+		}
+		for _, d := range b.Documents {
+			if existing, ok := docs[d.Domain]; ok && existing.ts >= ts {
+				continue
+			}
+			docs[d.Domain] = docEntry{ts: ts, doc: d}
+		}
+		for _, r := range b.Revocations {
+			if existing, ok := revs[r.Domain]; ok && existing.ts >= ts {
+				continue
+			}
+			revs[r.Domain] = revEntry{ts: ts, rev: r}
+		}
+	}
+
+	documents := make([]BundledDiscovery, 0, len(docs))
+	for _, e := range docs {
+		documents = append(documents, e.doc)
+	}
+	sort.Slice(documents, func(i, j int) bool { return documents[i].Domain < documents[j].Domain })
+
+	revocations := make([]revocation.RevocationDocument, 0, len(revs))
+	for _, e := range revs {
+		revocations = append(revocations, e.rev)
+	}
+	sort.Slice(revocations, func(i, j int) bool { return revocations[i].Domain < revocations[j].Domain })
+
+	return &SchemaPinTrustBundle{
+		SchemapinBundleVersion: BundleVersionSigned,
+		CreatedAt:              newestTS,
+		Documents:              documents,
+		Revocations:            revocations,
+	}
+}
+
+// BuildTrustBundleRequest builds a schemapin/trustBundle JSON-RPC request.
+// domain optionally scopes the request to a single provider; pass an empty
+// string for "send your whole bundle". id is the JSON-RPC request id.
+func BuildTrustBundleRequest(domain string, id interface{}) map[string]interface{} {
+	params := map[string]interface{}{}
+	if domain != "" {
+		params["domain"] = domain
+	}
+	return map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  "schemapin/trustBundle",
+		"params":  params,
+		"id":      id,
+	}
+}
+
+// BuildTrustBundleResponse builds a schemapin/trustBundle JSON-RPC response
+// carrying a (typically signed) bundle.
+func BuildTrustBundleResponse(b *SchemaPinTrustBundle, id interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"jsonrpc": "2.0",
+		"result": map[string]interface{}{
+			"bundle": b,
+		},
+		"id": id,
+	}
+}
+
+// ParseTrustBundleResponse extracts the bundle from a schemapin/trustBundle
+// JSON-RPC response (a generic map, e.g. from json.Unmarshal). A missing
+// result.bundle yields a *BundleError with ErrDiscoveryInvalid.
+func ParseTrustBundleResponse(response map[string]interface{}) (*SchemaPinTrustBundle, error) {
+	result, ok := response["result"].(map[string]interface{})
+	if !ok {
+		return nil, newBundleError(ErrDiscoveryInvalid, "JSON-RPC response missing result.bundle")
+	}
+	bundleVal, ok := result["bundle"]
+	if !ok {
+		return nil, newBundleError(ErrDiscoveryInvalid, "JSON-RPC response missing result.bundle")
+	}
+	raw, err := json.Marshal(bundleVal)
+	if err != nil {
+		return nil, err
+	}
+	var b SchemaPinTrustBundle
+	if err := json.Unmarshal(raw, &b); err != nil {
+		return nil, err
+	}
+	return &b, nil
+}
+
+// clone returns a copy of the bundle suitable for signing (the signature and
+// stamped fields are overwritten; the documents / revocations slices are shared
+// but never mutated by signing).
+func (b *SchemaPinTrustBundle) clone() *SchemaPinTrustBundle {
+	cp := *b
+	if b.BundleAuthority != nil {
+		ba := *b.BundleAuthority
+		cp.BundleAuthority = &ba
+	}
+	return &cp
+}

--- a/go/pkg/bundle/distribution_test.go
+++ b/go/pkg/bundle/distribution_test.go
@@ -1,0 +1,297 @@
+package bundle
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ThirdKeyAi/schemapin/go/pkg/crypto"
+	"github.com/ThirdKeyAi/schemapin/go/pkg/discovery"
+	"github.com/ThirdKeyAi/schemapin/go/pkg/revocation"
+)
+
+func genKeyPair(t *testing.T) (privPEM string) {
+	t.Helper()
+	km := crypto.NewKeyManager()
+	priv, err := km.GenerateKeypair()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	privPEM, err = km.ExportPrivateKeyPEM(priv)
+	if err != nil {
+		t.Fatalf("export private key: %v", err)
+	}
+	return privPEM
+}
+
+func makeDistBundle(domain, createdAt string) *SchemaPinTrustBundle {
+	return &SchemaPinTrustBundle{
+		SchemapinBundleVersion: "1.2",
+		CreatedAt:              createdAt,
+		Documents: []BundledDiscovery{
+			{
+				Domain: domain,
+				WellKnown: discovery.WellKnownResponse{
+					SchemaVersion: "1.2",
+					DeveloperName: "Example",
+					PublicKeyPEM:  "-----BEGIN PUBLIC KEY-----\nx\n-----END PUBLIC KEY-----",
+				},
+			},
+		},
+		Revocations: []revocation.RevocationDocument{},
+	}
+}
+
+func bundleErrCode(t *testing.T, err error) ErrorCode {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	be, ok := err.(*BundleError)
+	if !ok {
+		t.Fatalf("expected *BundleError, got %T: %v", err, err)
+	}
+	return be.Code
+}
+
+func TestSignVerifyRoundtrip(t *testing.T) {
+	priv := genKeyPair(t)
+	b := makeDistBundle("example.com", "2026-05-15T00:00:00Z")
+	signed, err := SignTrustBundle(b, priv, "auth-2026-05", "2026-05-15T00:00:00Z", "")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if signed.SchemapinBundleVersion != "1.4" {
+		t.Errorf("version = %q, want 1.4", signed.SchemapinBundleVersion)
+	}
+	if signed.Signature == "" {
+		t.Error("signature is empty")
+	}
+	if signed.BundleAuthority == nil || signed.BundleAuthority.Kid != "auth-2026-05" {
+		t.Errorf("bundle_authority kid mismatch: %+v", signed.BundleAuthority)
+	}
+
+	store := NewAuthorityPinStore()
+	if err := VerifyTrustBundle(signed, store); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+}
+
+func TestTamperedBundleFails(t *testing.T) {
+	priv := genKeyPair(t)
+	b := makeDistBundle("example.com", "2026-05-15T00:00:00Z")
+	signed, err := SignTrustBundle(b, priv, "auth", "2026-05-15T00:00:00Z", "")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	signed.Documents[0].Domain = "evil.com"
+
+	store := NewAuthorityPinStore()
+	code := bundleErrCode(t, VerifyTrustBundle(signed, store))
+	if code != ErrSignatureInvalid {
+		t.Errorf("code = %q, want %q", code, ErrSignatureInvalid)
+	}
+}
+
+func TestUnsignedBundleRejected(t *testing.T) {
+	b := makeDistBundle("example.com", "2026-05-15T00:00:00Z")
+	store := NewAuthorityPinStore()
+	code := bundleErrCode(t, VerifyTrustBundle(b, store))
+	if code != ErrBundleUnsigned {
+		t.Errorf("code = %q, want %q", code, ErrBundleUnsigned)
+	}
+}
+
+func TestExpiredBundleRejected(t *testing.T) {
+	priv := genKeyPair(t)
+	b := makeDistBundle("example.com", "2020-01-01T00:00:00Z")
+	signed, err := SignTrustBundle(b, priv, "auth", "2020-01-01T00:00:00Z", "2020-02-01T00:00:00Z")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	store := NewAuthorityPinStore()
+	code := bundleErrCode(t, VerifyTrustBundle(signed, store))
+	if code != ErrBundleExpired {
+		t.Errorf("code = %q, want %q", code, ErrBundleExpired)
+	}
+}
+
+func TestExpiredBundleUnparseable(t *testing.T) {
+	priv := genKeyPair(t)
+	b := makeDistBundle("example.com", "2026-05-15T00:00:00Z")
+	signed, err := SignTrustBundle(b, priv, "auth", "2026-05-15T00:00:00Z", "")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	signed.ExpiresAt = "not-a-date"
+	store := NewAuthorityPinStore()
+	code := bundleErrCode(t, VerifyTrustBundle(signed, store))
+	if code != ErrBundleExpired {
+		t.Errorf("code = %q, want %q", code, ErrBundleExpired)
+	}
+}
+
+func TestAuthorityTOFUMismatch(t *testing.T) {
+	priv1 := genKeyPair(t)
+	priv2 := genKeyPair(t)
+	b := makeDistBundle("example.com", "2026-05-15T00:00:00Z")
+
+	signed1, err := SignTrustBundle(b, priv1, "auth", "2026-05-15T00:00:00Z", "")
+	if err != nil {
+		t.Fatalf("sign1: %v", err)
+	}
+	// Different key, SAME kid -> impersonation attempt.
+	signed2, err := SignTrustBundle(b, priv2, "auth", "2026-05-16T00:00:00Z", "")
+	if err != nil {
+		t.Fatalf("sign2: %v", err)
+	}
+
+	store := NewAuthorityPinStore()
+	if err := VerifyTrustBundle(signed1, store); err != nil {
+		t.Fatalf("verify1 (pins kp1): %v", err)
+	}
+	code := bundleErrCode(t, VerifyTrustBundle(signed2, store))
+	if code != ErrKeyPinMismatch {
+		t.Errorf("code = %q, want %q", code, ErrKeyPinMismatch)
+	}
+}
+
+func TestMergeNewestWins(t *testing.T) {
+	older := makeDistBundle("example.com", "2026-01-01T00:00:00Z")
+	older.Documents[0].WellKnown.DeveloperName = "Old"
+	newer := makeDistBundle("example.com", "2026-05-01T00:00:00Z")
+	newer.Documents[0].WellKnown.DeveloperName = "New"
+	other := makeDistBundle("other.com", "2026-03-01T00:00:00Z")
+
+	merged := MergeTrustBundles([]*SchemaPinTrustBundle{older, newer, other})
+	if len(merged.Documents) != 2 {
+		t.Fatalf("documents len = %d, want 2", len(merged.Documents))
+	}
+	ex := merged.FindDiscovery("example.com")
+	if ex == nil || ex.DeveloperName != "New" {
+		t.Errorf("example.com developer_name = %v, want New", ex)
+	}
+	if merged.CreatedAt != "2026-05-01T00:00:00Z" {
+		t.Errorf("created_at = %q, want 2026-05-01T00:00:00Z", merged.CreatedAt)
+	}
+	if merged.SchemapinBundleVersion != "1.4" {
+		t.Errorf("version = %q, want 1.4", merged.SchemapinBundleVersion)
+	}
+}
+
+func TestMergeSignedAtBeatsCreatedAt(t *testing.T) {
+	a := makeDistBundle("example.com", "2026-01-01T00:00:00Z")
+	a.SignedAt = "2026-09-01T00:00:00Z"
+	a.Documents[0].WellKnown.DeveloperName = "Signed-late"
+	b := makeDistBundle("example.com", "2026-06-01T00:00:00Z")
+	b.Documents[0].WellKnown.DeveloperName = "Created-mid"
+
+	merged := MergeTrustBundles([]*SchemaPinTrustBundle{b, a})
+	ex := merged.FindDiscovery("example.com")
+	if ex == nil || ex.DeveloperName != "Signed-late" {
+		t.Errorf("developer_name = %v, want Signed-late", ex)
+	}
+}
+
+func TestJSONRPCEnvelopeRoundtrip(t *testing.T) {
+	priv := genKeyPair(t)
+	b := makeDistBundle("example.com", "2026-05-15T00:00:00Z")
+	signed, err := SignTrustBundle(b, priv, "auth", "2026-05-15T00:00:00Z", "")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	req := BuildTrustBundleRequest("example.com", 1)
+	if req["method"] != "schemapin/trustBundle" {
+		t.Errorf("method = %v", req["method"])
+	}
+	params := req["params"].(map[string]interface{})
+	if params["domain"] != "example.com" {
+		t.Errorf("params.domain = %v", params["domain"])
+	}
+
+	resp := BuildTrustBundleResponse(signed, 1)
+	// Round-trip through JSON to emulate the wire.
+	raw, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal resp: %v", err)
+	}
+	var generic map[string]interface{}
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		t.Fatalf("unmarshal resp: %v", err)
+	}
+	parsed, err := ParseTrustBundleResponse(generic)
+	if err != nil {
+		t.Fatalf("parse resp: %v", err)
+	}
+
+	// The parsed bundle still verifies.
+	store := NewAuthorityPinStore()
+	if err := VerifyTrustBundle(parsed, store); err != nil {
+		t.Fatalf("verify parsed: %v", err)
+	}
+}
+
+func TestParseTrustBundleResponseMissingBundle(t *testing.T) {
+	resp := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"result":  map[string]interface{}{},
+		"id":      1,
+	}
+	_, err := ParseTrustBundleResponse(resp)
+	code := bundleErrCode(t, err)
+	if code != ErrDiscoveryInvalid {
+		t.Errorf("code = %q, want %q", code, ErrDiscoveryInvalid)
+	}
+}
+
+func TestBuildTrustBundleRequestOmitsEmptyDomain(t *testing.T) {
+	req := BuildTrustBundleRequest("", 1)
+	params := req["params"].(map[string]interface{})
+	if _, ok := params["domain"]; ok {
+		t.Errorf("domain should be omitted when empty, got %v", params["domain"])
+	}
+}
+
+// TestCrossLanguageFixture is the key interop proof: the bundle signed by the
+// Rust SDK (tests/cross-language/signed_bundle.json) MUST verify in Go. If this
+// fails the canonicalization diverges from Rust.
+func TestCrossLanguageFixture(t *testing.T) {
+	path := findFixture(t)
+	raw, err := os.ReadFile(path) //nolint:gosec // test fixture path
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var b SchemaPinTrustBundle
+	if err := json.Unmarshal(raw, &b); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	store := NewAuthorityPinStore()
+	if err := VerifyTrustBundle(&b, store); err != nil {
+		t.Fatalf("cross-language fixture failed to verify: %v", err)
+	}
+}
+
+// findFixture resolves tests/cross-language/signed_bundle.json relative to the
+// repo root, walking up from the test working directory.
+func findFixture(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		candidate := filepath.Join(dir, "tests", "cross-language", "signed_bundle.json")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatalf("could not locate tests/cross-language/signed_bundle.json from %s", dir)
+	return ""
+}

--- a/go/pkg/verification/verification.go
+++ b/go/pkg/verification/verification.go
@@ -44,6 +44,13 @@ const (
 	// ErrA2AScopeViolation (v1.4 alpha.3) — A2A scope violation (provider
 	// domain not in caller's trusted_domains, or delegation_depth exceeded).
 	ErrA2AScopeViolation ErrorCode = "a2a_scope_violation"
+	// ErrBundleUnsigned (v1.4) — a trust bundle was passed to VerifyTrustBundle
+	// without a bundle_authority / signature pair. Bundle distribution requires
+	// a signed bundle.
+	ErrBundleUnsigned ErrorCode = "bundle_unsigned"
+	// ErrBundleExpired (v1.4) — a signed trust bundle's expires_at is in the
+	// past (or unparseable).
+	ErrBundleExpired ErrorCode = "bundle_expired"
 )
 
 // CanonicalizationV1 is the algorithm identifier (v1.4 alpha.3) for the

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "schemapin",
-  "version": "1.4.0-alpha.2",
+  "version": "1.4.0-alpha.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "schemapin",
-      "version": "1.4.0-alpha.2",
+      "version": "1.4.0-alpha.4",
       "cpu": [
         "x64",
         "arm64"
@@ -305,6 +305,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -554,6 +555,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schemapin",
-  "version": "1.4.0-alpha.3",
+  "version": "1.4.0-alpha.4",
   "description": "Cryptographic schema integrity verification for AI tools",
   "main": "src/index.js",
   "type": "module",

--- a/javascript/src/bundle.js
+++ b/javascript/src/bundle.js
@@ -1,6 +1,64 @@
 /**
  * Trust bundles for offline/air-gapped SchemaPin verification.
+ *
+ * v1.4 (A2A trust-bundle distribution): a *bundle authority* can sign a trust
+ * bundle so it can be exchanged between agents over A2A without per-bundle
+ * out-of-band trust establishment. This module provides:
+ *
+ * - {@link signTrustBundle} / {@link verifyTrustBundle} — ECDSA P-256 over the
+ *   canonical bundle bytes, with TOFU pinning of the authority key by `kid`.
+ * - {@link mergeTrustBundles} — combine bundles from multiple sources, newest
+ *   entry wins per domain.
+ * - {@link buildTrustBundleRequest} / {@link buildTrustBundleResponse} /
+ *   {@link parseTrustBundleResponse} — the `schemapin/trustBundle` JSON-RPC
+ *   envelope for A2A bundle exchange.
+ *
+ * ## Signing input
+ *
+ * The signature covers the `schemapin-v1` canonicalization (recursive sorted
+ * keys, compact, UTF-8) of the entire bundle object with the `signature` field
+ * set to the empty string `""`. All four SDKs build the identical byte string,
+ * so a bundle signed by any SDK verifies in every other.
  */
+
+import { createPublicKey } from 'crypto';
+import { SchemaPinCore } from './core.js';
+import { KeyManager, SignatureManager } from './crypto.js';
+import { ErrorCode } from './verification.js';
+
+/** Bundle-distribution wire format version stamped on signed bundles. */
+export const BUNDLE_VERSION_SIGNED = '1.4';
+
+/**
+ * Sentinel "domain" used to key bundle-authority pins in a {@link KeyPinStore}.
+ * Authorities are pinned by `kid`, independent of any tool domain.
+ */
+export const BUNDLE_AUTHORITY_PIN_DOMAIN = '_bundle_authority';
+
+/**
+ * Build a verification-style Error carrying a structured `.code`.
+ *
+ * @param {string} code - One of {@link ErrorCode}
+ * @param {string} message
+ * @returns {Error}
+ */
+function bundleError(code, message) {
+    const err = new Error(message);
+    err.code = code;
+    return err;
+}
+
+/**
+ * Build the canonical bytes that a bundle's signature covers: the bundle with
+ * its `signature` field forced to `""`, `schemapin-v1`-canonicalized.
+ *
+ * @param {Object} bundle
+ * @returns {string} Canonical JSON string
+ */
+function signingBytes(bundle) {
+    const obj = { ...bundle, signature: '' };
+    return SchemaPinCore.canonicalizeSchema(obj);
+}
 
 /**
  * Create an empty trust bundle.
@@ -70,4 +128,224 @@ export function findRevocation(bundle, domain) {
  */
 export function parseTrustBundle(jsonStr) {
     return JSON.parse(jsonStr);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// v1.4 — A2A trust-bundle distribution
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Sign a trust bundle with a bundle-authority key.
+ *
+ * Stamps `bundle_authority` (derived public key + `kid`),
+ * `schemapin_bundle_version = "1.4"`, `signed_at`, and optional `expires_at`,
+ * then writes the base64 DER ECDSA P-256 `signature`. `signedAt` / `expiresAt`
+ * are caller-supplied RFC 3339 strings (kept out of the core so signing is
+ * deterministic and cross-language testable).
+ *
+ * @param {Object} bundle - Trust bundle to sign
+ * @param {string} privateKeyPem - PEM-encoded ECDSA P-256 private key
+ * @param {string} kid - Bundle authority key id
+ * @param {string} signedAt - RFC 3339 timestamp
+ * @param {string|null} [expiresAt=null] - Optional RFC 3339 expiry
+ * @returns {Object} Signed trust bundle
+ */
+export function signTrustBundle(bundle, privateKeyPem, kid, signedAt, expiresAt = null) {
+    // Derive the authority public key PEM from the private key.
+    const publicKeyPem = createPublicKey(privateKeyPem)
+        .export({ type: 'spki', format: 'pem' });
+
+    // Build the signed bundle, omitting absent optional fields so the
+    // canonical form matches the Rust reference exactly.
+    const signed = {
+        schemapin_bundle_version: BUNDLE_VERSION_SIGNED,
+        created_at: bundle.created_at,
+        documents: bundle.documents ? [...bundle.documents] : [],
+        revocations: bundle.revocations ? [...bundle.revocations] : [],
+        bundle_authority: { kid, public_key_pem: publicKeyPem },
+        signed_at: signedAt
+    };
+    if (expiresAt !== null && expiresAt !== undefined) {
+        signed.expires_at = expiresAt;
+    }
+
+    const canonical = signingBytes(signed);
+    signed.signature = SignatureManager.signHash(
+        Buffer.from(canonical, 'utf8'),
+        privateKeyPem
+    );
+    return signed;
+}
+
+/**
+ * Verify a signed trust bundle and TOFU-pin its authority key by `kid`.
+ *
+ * Steps: require `bundle_authority` + `signature` (else `BUNDLE_UNSIGNED`);
+ * reject when `expires_at` is in the past or unparseable (`BUNDLE_EXPIRED`);
+ * TOFU-pin the authority's key fingerprint by `kid` (mismatch →
+ * `KEY_PIN_MISMATCH`); verify the signature over the canonical bytes
+ * (failure → `SIGNATURE_INVALID`).
+ *
+ * @param {Object} bundle - Signed trust bundle
+ * @param {import('./verification.js').KeyPinStore} authorityPinStore
+ * @returns {boolean} `true` on success
+ * @throws {Error} With `.code` set to the relevant {@link ErrorCode}
+ */
+export function verifyTrustBundle(bundle, authorityPinStore) {
+    const authority = bundle.bundle_authority;
+    if (!authority) {
+        throw bundleError(ErrorCode.BUNDLE_UNSIGNED, 'trust bundle has no bundle_authority');
+    }
+    const signature = bundle.signature;
+    if (!signature) {
+        throw bundleError(ErrorCode.BUNDLE_UNSIGNED, 'trust bundle has no signature');
+    }
+
+    if (bundle.expires_at !== null && bundle.expires_at !== undefined) {
+        const exp = new Date(bundle.expires_at);
+        if (Number.isNaN(exp.getTime())) {
+            throw bundleError(
+                ErrorCode.BUNDLE_EXPIRED,
+                `unparseable expires_at '${bundle.expires_at}'`
+            );
+        }
+        if (Date.now() > exp.getTime()) {
+            throw bundleError(
+                ErrorCode.BUNDLE_EXPIRED,
+                `trust bundle expired at ${bundle.expires_at}`
+            );
+        }
+    }
+
+    const fingerprint = KeyManager.calculateKeyFingerprint(authority.public_key_pem);
+    const pinResult = authorityPinStore.checkAndPin(
+        authority.kid,
+        BUNDLE_AUTHORITY_PIN_DOMAIN,
+        fingerprint
+    );
+    if (pinResult === 'changed') {
+        throw bundleError(
+            ErrorCode.KEY_PIN_MISMATCH,
+            `bundle authority key for kid '${authority.kid}' changed since last use`
+        );
+    }
+
+    const canonical = signingBytes(bundle);
+    const valid = SignatureManager.verifySignature(
+        Buffer.from(canonical, 'utf8'),
+        signature,
+        authority.public_key_pem
+    );
+    if (!valid) {
+        throw bundleError(
+            ErrorCode.SIGNATURE_INVALID,
+            'trust bundle signature does not verify'
+        );
+    }
+    return true;
+}
+
+/**
+ * Merge trust bundles, deduplicating discovery + revocation documents by
+ * domain. When two bundles carry the same domain, the entry from the bundle
+ * with the newer timestamp (`signed_at`, else `created_at`) wins.
+ *
+ * The result is an *unsigned* bundle (a merge cannot carry a single
+ * authority's signature) stamped `schemapin_bundle_version = "1.4"` with
+ * `created_at` set to the newest source timestamp. Re-sign it with
+ * {@link signTrustBundle} before redistribution. Documents and revocations are
+ * sorted by domain.
+ *
+ * @param {Object[]} bundles
+ * @returns {Object} Merged unsigned trust bundle
+ */
+export function mergeTrustBundles(bundles) {
+    // domain -> { ts, doc }
+    const docs = new Map();
+    const revs = new Map();
+    let newestTs = '';
+
+    for (const b of bundles) {
+        const ts = b.signed_at ?? b.created_at ?? '';
+        if (ts > newestTs) {
+            newestTs = ts;
+        }
+        for (const d of b.documents ?? []) {
+            const existing = docs.get(d.domain);
+            if (!existing || existing.ts < ts) {
+                docs.set(d.domain, { ts, doc: d });
+            }
+        }
+        for (const r of b.revocations ?? []) {
+            const existing = revs.get(r.domain);
+            if (!existing || existing.ts < ts) {
+                revs.set(r.domain, { ts, doc: r });
+            }
+        }
+    }
+
+    const documents = [...docs.values()]
+        .map((e) => e.doc)
+        .sort((a, b) => (a.domain < b.domain ? -1 : a.domain > b.domain ? 1 : 0));
+    const revocations = [...revs.values()]
+        .map((e) => e.doc)
+        .sort((a, b) => (a.domain < b.domain ? -1 : a.domain > b.domain ? 1 : 0));
+
+    return {
+        schemapin_bundle_version: BUNDLE_VERSION_SIGNED,
+        created_at: newestTs,
+        documents,
+        revocations
+    };
+}
+
+/**
+ * Build a `schemapin/trustBundle` JSON-RPC request. `domain` optionally scopes
+ * the request to a single provider; omit (null) for "send your whole bundle".
+ *
+ * @param {string|null} domain
+ * @param {number|string} id - JSON-RPC request id
+ * @returns {Object} JSON-RPC request envelope
+ */
+export function buildTrustBundleRequest(domain, id) {
+    const params = (domain !== null && domain !== undefined) ? { domain } : {};
+    return {
+        jsonrpc: '2.0',
+        method: 'schemapin/trustBundle',
+        params,
+        id
+    };
+}
+
+/**
+ * Build a `schemapin/trustBundle` JSON-RPC response carrying a bundle.
+ *
+ * @param {Object} bundle
+ * @param {number|string} id - JSON-RPC response id
+ * @returns {Object} JSON-RPC response envelope
+ */
+export function buildTrustBundleResponse(bundle, id) {
+    return {
+        jsonrpc: '2.0',
+        result: { bundle },
+        id
+    };
+}
+
+/**
+ * Extract the bundle from a `schemapin/trustBundle` JSON-RPC response.
+ *
+ * @param {Object} response - JSON-RPC response envelope
+ * @returns {Object} Trust bundle
+ * @throws {Error} With `.code = DISCOVERY_INVALID` when `result.bundle` absent
+ */
+export function parseTrustBundleResponse(response) {
+    const bundle = response?.result?.bundle;
+    if (bundle === undefined || bundle === null) {
+        throw bundleError(
+            ErrorCode.DISCOVERY_INVALID,
+            'JSON-RPC response missing result.bundle'
+        );
+    }
+    return bundle;
 }

--- a/javascript/src/index.js
+++ b/javascript/src/index.js
@@ -36,7 +36,16 @@ export {
     createBundledDiscovery,
     findDiscovery,
     findRevocation,
-    parseTrustBundle
+    parseTrustBundle,
+    // v1.4: A2A trust-bundle distribution
+    BUNDLE_VERSION_SIGNED,
+    BUNDLE_AUTHORITY_PIN_DOMAIN,
+    signTrustBundle,
+    verifyTrustBundle,
+    mergeTrustBundles,
+    buildTrustBundleRequest,
+    buildTrustBundleResponse,
+    parseTrustBundleResponse
 } from './bundle.js';
 export {
     SchemaResolver,

--- a/javascript/src/verification.js
+++ b/javascript/src/verification.js
@@ -63,7 +63,13 @@ export const ErrorCode = Object.freeze({
     CANONICALIZATION_UNSUPPORTED: 'canonicalization_unsupported',
     // v1.4 alpha.3: A2A scope violation (provider domain not in caller's
     // trusted_domains, or delegation_depth exceeded).
-    A2A_SCOPE_VIOLATION: 'a2a_scope_violation'
+    A2A_SCOPE_VIOLATION: 'a2a_scope_violation',
+    // v1.4 alpha.3 (bundle distribution): a trust bundle lacks the
+    // bundle_authority / signature required to verify it.
+    BUNDLE_UNSIGNED: 'bundle_unsigned',
+    // v1.4 alpha.3 (bundle distribution): a trust bundle is past its
+    // expires_at (or has an unparseable expires_at).
+    BUNDLE_EXPIRED: 'bundle_expired'
 });
 
 /**

--- a/javascript/tests/bundle-distribution.test.js
+++ b/javascript/tests/bundle-distribution.test.js
@@ -1,0 +1,181 @@
+/**
+ * Tests for v1.4 A2A trust-bundle distribution (sign / verify / merge /
+ * JSON-RPC envelope), mirroring rust/src/bundle.rs tests, plus a
+ * cross-language fixture test proving canonicalization agreement.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+import {
+    signTrustBundle,
+    verifyTrustBundle,
+    mergeTrustBundles,
+    buildTrustBundleRequest,
+    buildTrustBundleResponse,
+    parseTrustBundleResponse,
+    createTrustBundle,
+    createBundledDiscovery
+} from '../src/bundle.js';
+import { ErrorCode, KeyPinStore } from '../src/verification.js';
+import { KeyManager } from '../src/crypto.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// javascript/tests -> repo root is two levels up.
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const FIXTURE_PATH = resolve(REPO_ROOT, 'tests', 'cross-language', 'signed_bundle.json');
+
+function makeBundle(domain, createdAt) {
+    const wellKnown = {
+        schema_version: '1.2',
+        developer_name: 'Example',
+        public_key_pem: '-----BEGIN PUBLIC KEY-----\nx\n-----END PUBLIC KEY-----',
+        revoked_keys: []
+    };
+    const bundle = createTrustBundle(createdAt);
+    bundle.documents.push(createBundledDiscovery(domain, wellKnown));
+    return bundle;
+}
+
+describe('TrustBundle distribution (v1.4)', () => {
+    it('sign/verify roundtrip', () => {
+        const { privateKey } = KeyManager.generateKeypair();
+        const bundle = makeBundle('example.com', '2026-05-15T00:00:00Z');
+        const signed = signTrustBundle(
+            bundle, privateKey, 'auth-2026-05', '2026-05-15T00:00:00Z'
+        );
+
+        assert.equal(signed.schemapin_bundle_version, '1.4');
+        assert.ok(signed.signature);
+        assert.equal(signed.bundle_authority.kid, 'auth-2026-05');
+        assert.equal(signed.expires_at, undefined);
+
+        const store = new KeyPinStore();
+        assert.equal(verifyTrustBundle(signed, store), true);
+    });
+
+    it('tampered bundle fails with SIGNATURE_INVALID', () => {
+        const { privateKey } = KeyManager.generateKeypair();
+        const bundle = makeBundle('example.com', '2026-05-15T00:00:00Z');
+        const signed = signTrustBundle(
+            bundle, privateKey, 'auth', '2026-05-15T00:00:00Z'
+        );
+        signed.documents[0].domain = 'evil.com';
+
+        const store = new KeyPinStore();
+        assert.throws(
+            () => verifyTrustBundle(signed, store),
+            (e) => e.code === ErrorCode.SIGNATURE_INVALID
+        );
+    });
+
+    it('unsigned bundle rejected with BUNDLE_UNSIGNED', () => {
+        const bundle = makeBundle('example.com', '2026-05-15T00:00:00Z');
+        const store = new KeyPinStore();
+        assert.throws(
+            () => verifyTrustBundle(bundle, store),
+            (e) => e.code === ErrorCode.BUNDLE_UNSIGNED
+        );
+    });
+
+    it('expired bundle rejected with BUNDLE_EXPIRED', () => {
+        const { privateKey } = KeyManager.generateKeypair();
+        const bundle = makeBundle('example.com', '2020-01-01T00:00:00Z');
+        const signed = signTrustBundle(
+            bundle, privateKey, 'auth', '2020-01-01T00:00:00Z', '2020-02-01T00:00:00Z'
+        );
+        const store = new KeyPinStore();
+        assert.throws(
+            () => verifyTrustBundle(signed, store),
+            (e) => e.code === ErrorCode.BUNDLE_EXPIRED
+        );
+    });
+
+    it('authority TOFU mismatch rejected with KEY_PIN_MISMATCH', () => {
+        const kp1 = KeyManager.generateKeypair();
+        const kp2 = KeyManager.generateKeypair();
+        const bundle = makeBundle('example.com', '2026-05-15T00:00:00Z');
+
+        const signed1 = signTrustBundle(
+            bundle, kp1.privateKey, 'auth', '2026-05-15T00:00:00Z'
+        );
+        // Different key, SAME kid -> impersonation attempt.
+        const signed2 = signTrustBundle(
+            bundle, kp2.privateKey, 'auth', '2026-05-16T00:00:00Z'
+        );
+
+        const store = new KeyPinStore();
+        assert.equal(verifyTrustBundle(signed1, store), true); // pins kp1
+        assert.throws(
+            () => verifyTrustBundle(signed2, store),
+            (e) => e.code === ErrorCode.KEY_PIN_MISMATCH
+        );
+    });
+
+    it('merge newest wins (and across domains)', () => {
+        const older = makeBundle('example.com', '2026-01-01T00:00:00Z');
+        older.documents[0].developer_name = 'Old';
+        const newer = makeBundle('example.com', '2026-05-01T00:00:00Z');
+        newer.documents[0].developer_name = 'New';
+        const other = makeBundle('other.com', '2026-03-01T00:00:00Z');
+
+        const merged = mergeTrustBundles([older, newer, other]);
+        assert.equal(merged.schemapin_bundle_version, '1.4');
+        assert.equal(merged.documents.length, 2);
+        const ex = merged.documents.find((d) => d.domain === 'example.com');
+        assert.equal(ex.developer_name, 'New');
+        assert.equal(merged.created_at, '2026-05-01T00:00:00Z');
+        // Sorted by domain.
+        assert.deepEqual(merged.documents.map((d) => d.domain), ['example.com', 'other.com']);
+    });
+
+    it('merge: signed_at beats created_at', () => {
+        const a = makeBundle('example.com', '2026-01-01T00:00:00Z');
+        a.signed_at = '2026-09-01T00:00:00Z';
+        a.documents[0].developer_name = 'Signed-late';
+        const b = makeBundle('example.com', '2026-06-01T00:00:00Z');
+        b.documents[0].developer_name = 'Created-mid';
+
+        const merged = mergeTrustBundles([b, a]);
+        assert.equal(merged.documents[0].developer_name, 'Signed-late');
+    });
+
+    it('JSON-RPC envelope roundtrip', () => {
+        const { privateKey } = KeyManager.generateKeypair();
+        const bundle = makeBundle('example.com', '2026-05-15T00:00:00Z');
+        const signed = signTrustBundle(
+            bundle, privateKey, 'auth', '2026-05-15T00:00:00Z'
+        );
+
+        const req = buildTrustBundleRequest('example.com', 1);
+        assert.equal(req.method, 'schemapin/trustBundle');
+        assert.equal(req.params.domain, 'example.com');
+
+        const reqNoDomain = buildTrustBundleRequest(null, 2);
+        assert.deepEqual(reqNoDomain.params, {});
+
+        const resp = buildTrustBundleResponse(signed, 1);
+        const parsed = parseTrustBundleResponse(resp);
+        assert.deepEqual(parsed, signed);
+
+        const store = new KeyPinStore();
+        assert.equal(verifyTrustBundle(parsed, store), true);
+    });
+
+    it('parseTrustBundleResponse rejects missing result.bundle', () => {
+        assert.throws(
+            () => parseTrustBundleResponse({ jsonrpc: '2.0', result: {}, id: 1 }),
+            (e) => e.code === ErrorCode.DISCOVERY_INVALID
+        );
+    });
+
+    it('cross-language fixture verifies (interop proof)', () => {
+        const raw = readFileSync(FIXTURE_PATH, 'utf8');
+        const bundle = JSON.parse(raw);
+        const store = new KeyPinStore();
+        assert.equal(verifyTrustBundle(bundle, store), true);
+    });
+});

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schemapin"
-version = "1.4.0a3"
+version = "1.4.0a4"
 description = "Cryptographic schema integrity verification for AI tools"
 readme = "README.md"
 license = {text = "MIT"}

--- a/python/schemapin/__init__.py
+++ b/python/schemapin/__init__.py
@@ -1,8 +1,32 @@
 """SchemaPin: Cryptographic schema integrity verification for AI tools."""
 
+from .a2a import (
+    A2aVerificationContext,
+)
+from .a2a import (
+    allows as a2a_allows,
+)
+from .a2a import (
+    intersect as a2a_intersect,
+)
+from .a2a import (
+    is_unrestricted as a2a_is_unrestricted,
+)
 from .bundle import (
+    BundleAuthority,
     SchemaPinTrustBundle,
     create_bundled_discovery,
+)
+from .bundle_distribution import (
+    BUNDLE_AUTHORITY_PIN_DOMAIN,
+    BUNDLE_VERSION_SIGNED,
+    BundleVerificationError,
+    build_trust_bundle_request,
+    build_trust_bundle_response,
+    merge_trust_bundles,
+    parse_trust_bundle_response,
+    sign_trust_bundle,
+    verify_trust_bundle,
 )
 from .core import SchemaPinCore
 from .crypto import KeyManager, SignatureManager
@@ -65,14 +89,8 @@ from .verification import (
     verify_schema_offline,
     verify_schema_with_resolver,
 )
-from .a2a import (
-    A2aVerificationContext,
-    allows as a2a_allows,
-    intersect as a2a_intersect,
-    is_unrestricted as a2a_is_unrestricted,
-)
 
-__version__ = "1.4.0a3"
+__version__ = "1.4.0a4"
 __all__ = [
     "SchemaPinCore",
     "KeyManager",
@@ -134,4 +152,15 @@ __all__ = [
     "a2a_allows",
     "a2a_intersect",
     "a2a_is_unrestricted",
+    # v1.4 — A2A trust-bundle distribution
+    "BundleAuthority",
+    "BundleVerificationError",
+    "BUNDLE_VERSION_SIGNED",
+    "BUNDLE_AUTHORITY_PIN_DOMAIN",
+    "sign_trust_bundle",
+    "verify_trust_bundle",
+    "merge_trust_bundles",
+    "build_trust_bundle_request",
+    "build_trust_bundle_response",
+    "parse_trust_bundle_response",
 ]

--- a/python/schemapin/bundle.py
+++ b/python/schemapin/bundle.py
@@ -1,10 +1,36 @@
-"""Trust bundles for offline/air-gapped SchemaPin verification."""
+"""Trust bundles for offline/air-gapped SchemaPin verification.
+
+v1.4 adds optional distribution fields (``bundle_authority``, ``signed_at``,
+``expires_at``, ``signature``) so bundles can be signed by a bundle authority
+and safely exchanged between agents over A2A. See
+:mod:`schemapin.bundle_distribution` for the sign / verify / merge operations.
+"""
 
 import json
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 from .revocation import RevocationDocument
+
+
+@dataclass
+class BundleAuthority:
+    """(v1.4) Identifies and carries the public key of the authority that
+    signed a trust bundle. TOFU-pinned by ``kid`` on first use (see
+    :func:`schemapin.bundle_distribution.verify_trust_bundle`).
+    """
+
+    kid: str
+    public_key_pem: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dictionary."""
+        return {"kid": self.kid, "public_key_pem": self.public_key_pem}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "BundleAuthority":
+        """Deserialize from dictionary."""
+        return cls(kid=data["kid"], public_key_pem=data["public_key_pem"])
 
 
 @dataclass
@@ -15,6 +41,12 @@ class SchemaPinTrustBundle:
     created_at: str
     documents: List[Dict[str, Any]] = field(default_factory=list)
     revocations: List[RevocationDocument] = field(default_factory=list)
+    # (v1.4) Optional bundle-distribution fields. Present on signed bundles;
+    # omitted entirely (not serialized) on unsigned bundles.
+    bundle_authority: Optional[BundleAuthority] = None
+    signed_at: Optional[str] = None
+    expires_at: Optional[str] = None
+    signature: Optional[str] = None
 
     def find_discovery(self, domain: str) -> Optional[Dict[str, Any]]:
         """Find a discovery document for a domain.
@@ -35,17 +67,31 @@ class SchemaPinTrustBundle:
         return None
 
     def to_dict(self) -> Dict[str, Any]:
-        """Serialize to dictionary with flattened BundledDiscovery format."""
-        return {
+        """Serialize to dictionary with flattened BundledDiscovery format.
+
+        Optional v1.4 distribution fields are only included when present, so
+        unsigned bundles serialize identically to the pre-v1.4 wire format.
+        """
+        d: Dict[str, Any] = {
             "schemapin_bundle_version": self.schemapin_bundle_version,
             "created_at": self.created_at,
             "documents": self.documents,
             "revocations": [r.to_dict() for r in self.revocations],
         }
+        if self.bundle_authority is not None:
+            d["bundle_authority"] = self.bundle_authority.to_dict()
+        if self.signed_at is not None:
+            d["signed_at"] = self.signed_at
+        if self.expires_at is not None:
+            d["expires_at"] = self.expires_at
+        if self.signature is not None:
+            d["signature"] = self.signature
+        return d
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SchemaPinTrustBundle":
         """Deserialize from dictionary."""
+        ba = data.get("bundle_authority")
         return cls(
             schemapin_bundle_version=data["schemapin_bundle_version"],
             created_at=data["created_at"],
@@ -54,6 +100,10 @@ class SchemaPinTrustBundle:
                 RevocationDocument.from_dict(r)
                 for r in data.get("revocations", [])
             ],
+            bundle_authority=BundleAuthority.from_dict(ba) if ba else None,
+            signed_at=data.get("signed_at"),
+            expires_at=data.get("expires_at"),
+            signature=data.get("signature"),
         )
 
     @classmethod

--- a/python/schemapin/bundle_distribution.py
+++ b/python/schemapin/bundle_distribution.py
@@ -1,0 +1,244 @@
+"""(v1.4) Trust-bundle distribution for A2A networks.
+
+Lets a *bundle authority* sign a :class:`~schemapin.bundle.SchemaPinTrustBundle`
+so it can be exchanged between agents over A2A without per-bundle out-of-band
+trust establishment. Provides:
+
+- :func:`sign_trust_bundle` / :func:`verify_trust_bundle` — ECDSA P-256 over
+  the canonical bundle bytes, with TOFU pinning of the authority key by ``kid``.
+- :func:`merge_trust_bundles` — combine bundles from multiple sources, newest
+  entry wins per domain.
+- :func:`build_trust_bundle_request` / :func:`build_trust_bundle_response` /
+  :func:`parse_trust_bundle_response` — the ``schemapin/trustBundle`` JSON-RPC
+  envelope for A2A bundle exchange.
+
+Signing input
+-------------
+
+The signature covers the ``schemapin-v1`` canonicalization (recursive sorted
+keys, compact, UTF-8) of the entire bundle object with the ``signature`` field
+set to the empty string ``""``. All four SDKs build the identical byte string,
+so a bundle signed by any SDK verifies in every other.
+"""
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from .bundle import BundleAuthority, SchemaPinTrustBundle
+from .core import SchemaPinCore
+from .crypto import KeyManager, SignatureManager
+from .verification import ErrorCode, KeyPinStore, _parse_rfc3339
+
+#: Bundle-distribution wire format version stamped on signed bundles.
+BUNDLE_VERSION_SIGNED = "1.4"
+
+#: Sentinel "domain" used to key bundle-authority pins in a ``KeyPinStore``.
+#: Authorities are pinned by ``kid``, independent of any tool domain.
+BUNDLE_AUTHORITY_PIN_DOMAIN = "_bundle_authority"
+
+
+class BundleVerificationError(Exception):
+    """Raised when a trust bundle fails verification.
+
+    Carries a structured :class:`~schemapin.verification.ErrorCode` (e.g.
+    ``BUNDLE_UNSIGNED``, ``BUNDLE_EXPIRED``, ``KEY_PIN_MISMATCH``,
+    ``SIGNATURE_INVALID``) alongside the human-readable message.
+    """
+
+    def __init__(self, code: ErrorCode, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def _signing_bytes(bundle: SchemaPinTrustBundle) -> bytes:
+    """Build the canonical bytes a bundle's signature covers: the bundle with
+    its ``signature`` field forced to ``""``, ``schemapin-v1``-canonicalized.
+    """
+    obj = bundle.to_dict()
+    obj["signature"] = ""
+    canonical = SchemaPinCore.canonicalize_schema(obj)
+    return canonical.encode("utf-8")
+
+
+def sign_trust_bundle(
+    bundle: SchemaPinTrustBundle,
+    private_key_pem: str,
+    kid: str,
+    signed_at: str,
+    expires_at: Optional[str] = None,
+) -> SchemaPinTrustBundle:
+    """Sign a trust bundle with a bundle-authority key.
+
+    Stamps ``bundle_authority`` (derived public key + ``kid``),
+    ``schemapin_bundle_version = "1.4"``, ``signed_at``, and optional
+    ``expires_at``, then writes the base64 DER ECDSA P-256 ``signature``.
+    ``signed_at`` / ``expires_at`` are caller-supplied RFC 3339 strings (kept
+    out of the core so signing is deterministic and cross-language testable).
+    """
+    private_key = KeyManager.load_private_key_pem(private_key_pem)
+    public_key_pem = KeyManager.export_public_key_pem(private_key.public_key())
+
+    signed = SchemaPinTrustBundle(
+        schemapin_bundle_version=BUNDLE_VERSION_SIGNED,
+        created_at=bundle.created_at,
+        documents=list(bundle.documents),
+        revocations=list(bundle.revocations),
+        bundle_authority=BundleAuthority(kid=kid, public_key_pem=public_key_pem),
+        signed_at=signed_at,
+        expires_at=expires_at,
+        signature=None,
+    )
+
+    canonical = _signing_bytes(signed)
+    signed.signature = SignatureManager.sign_hash(canonical, private_key)
+    return signed
+
+
+def verify_trust_bundle(
+    bundle: SchemaPinTrustBundle,
+    authority_pin_store: KeyPinStore,
+) -> None:
+    """Verify a signed trust bundle and TOFU-pin its authority key by ``kid``.
+
+    Steps: require ``bundle_authority`` + ``signature`` (else
+    ``BUNDLE_UNSIGNED``); reject when ``expires_at`` is in the past or
+    unparseable (``BUNDLE_EXPIRED``); TOFU-pin the authority's key fingerprint
+    by ``kid`` (mismatch → ``KEY_PIN_MISMATCH``); verify the signature over the
+    canonical bytes (failure → ``SIGNATURE_INVALID``).
+
+    Returns ``None`` on success; raises :class:`BundleVerificationError`
+    otherwise.
+    """
+    authority = bundle.bundle_authority
+    if authority is None:
+        raise BundleVerificationError(
+            ErrorCode.BUNDLE_UNSIGNED, "trust bundle has no bundle_authority"
+        )
+    signature = bundle.signature
+    if signature is None:
+        raise BundleVerificationError(
+            ErrorCode.BUNDLE_UNSIGNED, "trust bundle has no signature"
+        )
+
+    if bundle.expires_at is not None:
+        exp = _parse_rfc3339(bundle.expires_at)
+        if exp is None:
+            raise BundleVerificationError(
+                ErrorCode.BUNDLE_EXPIRED,
+                f"unparseable expires_at '{bundle.expires_at}'",
+            )
+        if datetime.now(timezone.utc) > exp:
+            raise BundleVerificationError(
+                ErrorCode.BUNDLE_EXPIRED,
+                f"trust bundle expired at {bundle.expires_at}",
+            )
+
+    fingerprint = KeyManager.calculate_key_fingerprint_from_pem(
+        authority.public_key_pem
+    )
+    pin_result = authority_pin_store.check_and_pin(
+        authority.kid, BUNDLE_AUTHORITY_PIN_DOMAIN, fingerprint
+    )
+    if pin_result == "changed":
+        raise BundleVerificationError(
+            ErrorCode.KEY_PIN_MISMATCH,
+            f"bundle authority key for kid '{authority.kid}' changed since "
+            f"first use",
+        )
+
+    canonical = _signing_bytes(bundle)
+    public_key = KeyManager.load_public_key_pem(authority.public_key_pem)
+    if not SignatureManager.verify_signature(canonical, signature, public_key):
+        raise BundleVerificationError(
+            ErrorCode.SIGNATURE_INVALID,
+            "trust bundle signature does not verify",
+        )
+
+
+def _bundle_timestamp(bundle: SchemaPinTrustBundle) -> str:
+    """Sort timestamp for a bundle: ``signed_at`` if present, else ``created_at``."""
+    return bundle.signed_at if bundle.signed_at is not None else bundle.created_at
+
+
+def merge_trust_bundles(
+    bundles: List[SchemaPinTrustBundle],
+) -> SchemaPinTrustBundle:
+    """Merge trust bundles, deduplicating discovery + revocation documents by
+    domain. When two bundles carry the same domain, the entry from the bundle
+    with the newer timestamp (``signed_at``, else ``created_at``) wins.
+
+    The result is an *unsigned* bundle (a merge cannot carry a single
+    authority's signature) stamped ``schemapin_bundle_version = "1.4"`` with
+    ``created_at`` set to the newest source timestamp. Re-sign it with
+    :func:`sign_trust_bundle` before redistribution.
+    """
+    docs: Dict[str, Any] = {}  # domain -> (timestamp, document)
+    revs: Dict[str, Any] = {}  # domain -> (timestamp, RevocationDocument)
+    newest_ts = ""
+
+    for b in bundles:
+        ts = _bundle_timestamp(b)
+        if ts > newest_ts:
+            newest_ts = ts
+        for d in b.documents:
+            domain = d.get("domain")
+            existing = docs.get(domain)
+            if existing is None or existing[0] < ts:
+                docs[domain] = (ts, d)
+        for r in b.revocations:
+            existing = revs.get(r.domain)
+            if existing is None or existing[0] < ts:
+                revs[r.domain] = (ts, r)
+
+    documents = [v[1] for v in docs.values()]
+    documents.sort(key=lambda d: d.get("domain", ""))
+    revocations = [v[1] for v in revs.values()]
+    revocations.sort(key=lambda r: r.domain)
+
+    return SchemaPinTrustBundle(
+        schemapin_bundle_version=BUNDLE_VERSION_SIGNED,
+        created_at=newest_ts,
+        documents=documents,
+        revocations=revocations,
+    )
+
+
+def build_trust_bundle_request(
+    domain: Optional[str] = None, id: Any = None
+) -> Dict[str, Any]:
+    """Build a ``schemapin/trustBundle`` JSON-RPC request. ``domain`` optionally
+    scopes the request to a single provider; omit for "send your whole bundle".
+    """
+    params: Dict[str, Any] = {"domain": domain} if domain is not None else {}
+    return {
+        "jsonrpc": "2.0",
+        "method": "schemapin/trustBundle",
+        "params": params,
+        "id": id,
+    }
+
+
+def build_trust_bundle_response(
+    bundle: SchemaPinTrustBundle, id: Any = None
+) -> Dict[str, Any]:
+    """Build a ``schemapin/trustBundle`` JSON-RPC response carrying a bundle."""
+    return {
+        "jsonrpc": "2.0",
+        "result": {"bundle": bundle.to_dict()},
+        "id": id,
+    }
+
+
+def parse_trust_bundle_response(
+    response: Dict[str, Any],
+) -> SchemaPinTrustBundle:
+    """Extract the bundle from a ``schemapin/trustBundle`` JSON-RPC response."""
+    result = response.get("result")
+    bundle = result.get("bundle") if isinstance(result, dict) else None
+    if bundle is None:
+        raise BundleVerificationError(
+            ErrorCode.DISCOVERY_INVALID,
+            "JSON-RPC response missing result.bundle",
+        )
+    return SchemaPinTrustBundle.from_dict(bundle)

--- a/python/schemapin/verification.py
+++ b/python/schemapin/verification.py
@@ -29,6 +29,12 @@ class ErrorCode(Enum):
     # v1.4 alpha.3: A2A scope violation (provider domain not in caller's
     # trusted_domains, or delegation_depth exceeded).
     A2A_SCOPE_VIOLATION = "a2a_scope_violation"
+    # v1.4: a trust bundle was passed to verify_trust_bundle without a
+    # bundle_authority / signature pair. Bundle distribution requires a
+    # signed bundle.
+    BUNDLE_UNSIGNED = "bundle_unsigned"
+    # v1.4: a signed trust bundle's expires_at is in the past (or unparseable).
+    BUNDLE_EXPIRED = "bundle_expired"
 
 
 # v1.4 alpha.3: canonicalization algorithm identifier

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = schemapin
-version = 1.4.0a3
+version = 1.4.0a4
 author = ThirdKey
 author_email = contact@thirdkey.ai
 maintainer = Jascha Wanger

--- a/python/tests/test_bundle_distribution.py
+++ b/python/tests/test_bundle_distribution.py
@@ -1,0 +1,206 @@
+"""Tests for v1.4 A2A trust-bundle distribution (sign/verify/merge/JSON-RPC).
+
+Mirrors ``rust/src/bundle.rs`` tests. The cross-language fixture test is the
+key interop proof: it loads ``tests/cross-language/signed_bundle.json`` (signed
+by the Rust SDK) and asserts it verifies here, confirming the four SDKs agree
+on the bundle canonicalization and signing input.
+"""
+
+import os
+
+import pytest
+
+from schemapin.bundle import SchemaPinTrustBundle, create_bundled_discovery
+from schemapin.bundle_distribution import (
+    BundleVerificationError,
+    build_trust_bundle_request,
+    build_trust_bundle_response,
+    merge_trust_bundles,
+    parse_trust_bundle_response,
+    sign_trust_bundle,
+    verify_trust_bundle,
+)
+from schemapin.crypto import KeyManager
+from schemapin.verification import ErrorCode, KeyPinStore
+
+
+def _keypair_pem():
+    priv, _pub = KeyManager.generate_keypair()
+    return KeyManager.export_private_key_pem(priv)
+
+
+def _make_bundle(domain="example.com", created_at="2026-05-15T00:00:00Z",
+                 developer_name="Example"):
+    well_known = {
+        "schema_version": "1.2",
+        "developer_name": developer_name,
+        "public_key_pem": "-----BEGIN PUBLIC KEY-----\nx\n-----END PUBLIC KEY-----",
+        "revoked_keys": [],
+    }
+    doc = create_bundled_discovery(domain, well_known)
+    return SchemaPinTrustBundle(
+        schemapin_bundle_version="1.2",
+        created_at=created_at,
+        documents=[doc],
+    )
+
+
+class TestSignVerify:
+    def test_sign_verify_roundtrip(self):
+        priv = _keypair_pem()
+        bundle = _make_bundle()
+        signed = sign_trust_bundle(
+            bundle, priv, "auth-2026-05", "2026-05-15T00:00:00Z"
+        )
+
+        assert signed.schemapin_bundle_version == "1.4"
+        assert signed.signature is not None
+        assert signed.bundle_authority.kid == "auth-2026-05"
+
+        store = KeyPinStore()
+        # Returns None on success, does not raise.
+        assert verify_trust_bundle(signed, store) is None
+
+    def test_tampered_bundle_fails(self):
+        priv = _keypair_pem()
+        signed = sign_trust_bundle(
+            _make_bundle(), priv, "auth", "2026-05-15T00:00:00Z"
+        )
+        # Mutate a signed field.
+        signed.documents[0]["domain"] = "evil.com"
+
+        store = KeyPinStore()
+        with pytest.raises(BundleVerificationError) as ei:
+            verify_trust_bundle(signed, store)
+        assert ei.value.code == ErrorCode.SIGNATURE_INVALID
+
+    def test_unsigned_bundle_rejected(self):
+        bundle = _make_bundle()
+        store = KeyPinStore()
+        with pytest.raises(BundleVerificationError) as ei:
+            verify_trust_bundle(bundle, store)
+        assert ei.value.code == ErrorCode.BUNDLE_UNSIGNED
+
+    def test_expired_bundle_rejected(self):
+        priv = _keypair_pem()
+        signed = sign_trust_bundle(
+            _make_bundle(created_at="2020-01-01T00:00:00Z"),
+            priv,
+            "auth",
+            "2020-01-01T00:00:00Z",
+            expires_at="2020-02-01T00:00:00Z",
+        )
+        store = KeyPinStore()
+        with pytest.raises(BundleVerificationError) as ei:
+            verify_trust_bundle(signed, store)
+        assert ei.value.code == ErrorCode.BUNDLE_EXPIRED
+
+    def test_unparseable_expires_at_rejected(self):
+        priv = _keypair_pem()
+        signed = sign_trust_bundle(
+            _make_bundle(), priv, "auth", "2026-05-15T00:00:00Z",
+            expires_at="not-a-date",
+        )
+        store = KeyPinStore()
+        with pytest.raises(BundleVerificationError) as ei:
+            verify_trust_bundle(signed, store)
+        assert ei.value.code == ErrorCode.BUNDLE_EXPIRED
+
+    def test_authority_tofu_mismatch(self):
+        priv1 = _keypair_pem()
+        priv2 = _keypair_pem()
+        bundle = _make_bundle()
+
+        signed1 = sign_trust_bundle(bundle, priv1, "auth", "2026-05-15T00:00:00Z")
+        # Different key, SAME kid -> impersonation attempt.
+        signed2 = sign_trust_bundle(bundle, priv2, "auth", "2026-05-16T00:00:00Z")
+
+        store = KeyPinStore()
+        verify_trust_bundle(signed1, store)  # pins priv1
+        with pytest.raises(BundleVerificationError) as ei:
+            verify_trust_bundle(signed2, store)
+        assert ei.value.code == ErrorCode.KEY_PIN_MISMATCH
+
+
+class TestMerge:
+    def test_merge_newest_wins(self):
+        older = _make_bundle(created_at="2026-01-01T00:00:00Z",
+                             developer_name="Old")
+        newer = _make_bundle(created_at="2026-05-01T00:00:00Z",
+                             developer_name="New")
+        other = _make_bundle(domain="other.com",
+                             created_at="2026-03-01T00:00:00Z")
+
+        merged = merge_trust_bundles([older, newer, other])
+        assert len(merged.documents) == 2
+        ex = next(d for d in merged.documents if d["domain"] == "example.com")
+        assert ex["developer_name"] == "New"
+        assert merged.created_at == "2026-05-01T00:00:00Z"
+        assert merged.schemapin_bundle_version == "1.4"
+        # Merge result is unsigned.
+        assert merged.bundle_authority is None
+        assert merged.signature is None
+        # Sorted by domain for determinism.
+        assert [d["domain"] for d in merged.documents] == ["example.com", "other.com"]
+
+    def test_merge_signed_at_beats_created_at(self):
+        a = _make_bundle(created_at="2026-01-01T00:00:00Z",
+                        developer_name="Signed-late")
+        a.signed_at = "2026-09-01T00:00:00Z"
+        b = _make_bundle(created_at="2026-06-01T00:00:00Z",
+                        developer_name="Created-mid")
+
+        merged = merge_trust_bundles([b, a])
+        assert merged.documents[0]["developer_name"] == "Signed-late"
+
+
+class TestJsonRpcEnvelope:
+    def test_request_shape(self):
+        req = build_trust_bundle_request("example.com", id=1)
+        assert req["jsonrpc"] == "2.0"
+        assert req["method"] == "schemapin/trustBundle"
+        assert req["params"]["domain"] == "example.com"
+        assert req["id"] == 1
+
+    def test_request_no_domain(self):
+        req = build_trust_bundle_request(id=2)
+        assert req["params"] == {}
+
+    def test_envelope_roundtrip(self):
+        priv = _keypair_pem()
+        signed = sign_trust_bundle(
+            _make_bundle(), priv, "auth", "2026-05-15T00:00:00Z"
+        )
+
+        resp = build_trust_bundle_response(signed, id=1)
+        parsed = parse_trust_bundle_response(resp)
+        assert parsed.to_dict() == signed.to_dict()
+
+        # The parsed bundle still verifies.
+        store = KeyPinStore()
+        verify_trust_bundle(parsed, store)
+
+    def test_parse_missing_bundle(self):
+        with pytest.raises(BundleVerificationError) as ei:
+            parse_trust_bundle_response({"jsonrpc": "2.0", "result": {}, "id": 1})
+        assert ei.value.code == ErrorCode.DISCOVERY_INVALID
+
+
+class TestCrossLanguage:
+    def test_rust_signed_bundle_verifies(self):
+        """Load the shared Rust-signed fixture and verify it. This proves the
+        Python canonicalization / signing input matches the Rust reference.
+        """
+        # Resolve repo root robustly: this file lives at
+        # <root>/python/tests/test_bundle_distribution.py
+        here = os.path.dirname(os.path.abspath(__file__))
+        root = os.path.abspath(os.path.join(here, "..", ".."))
+        fixture = os.path.join(root, "tests", "cross-language", "signed_bundle.json")
+        assert os.path.exists(fixture), f"fixture not found: {fixture}"
+
+        with open(fixture, encoding="utf-8") as f:
+            bundle = SchemaPinTrustBundle.from_json(f.read())
+
+        store = KeyPinStore()
+        # Must not raise — interop proof.
+        assert verify_trust_bundle(bundle, store) is None

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "schemapin"
-version = "1.4.0-alpha.3"
+version = "1.4.0-alpha.4"
 dependencies = [
  "async-trait",
  "base64 0.21.7",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schemapin"
-version = "1.4.0-alpha.3"
+version = "1.4.0-alpha.4"
 edition = "2021"
 rust-version = "1.70"
 description = "Cryptographic schema integrity verification for AI tools - Rust implementation"

--- a/rust/src/bundle.rs
+++ b/rust/src/bundle.rs
@@ -1,0 +1,432 @@
+//! (v1.4) Trust-bundle distribution for A2A networks.
+//!
+//! Lets a *bundle authority* sign a [`SchemaPinTrustBundle`] so it can be
+//! exchanged between agents over A2A without per-bundle out-of-band trust
+//! establishment. Provides:
+//!
+//! - [`sign_trust_bundle`] / [`verify_trust_bundle`] — ECDSA P-256 over the
+//!   canonical bundle bytes, with TOFU pinning of the authority key by `kid`.
+//! - [`merge_trust_bundles`] — combine bundles from multiple sources, newest
+//!   entry wins per domain.
+//! - [`build_trust_bundle_request`] / [`build_trust_bundle_response`] /
+//!   [`parse_trust_bundle_response`] — the `schemapin/trustBundle` JSON-RPC
+//!   envelope for A2A bundle exchange.
+//!
+//! ## Signing input
+//!
+//! The signature covers the `schemapin-v1` canonicalization (recursive sorted
+//! keys, compact, UTF-8) of the entire bundle object with the `signature` field
+//! set to the empty string `""`. All four SDKs build the identical byte string,
+//! so a bundle signed by any SDK verifies in every other.
+
+use serde_json::{json, Value};
+
+use crate::canonicalize::canonicalize_schema;
+use crate::crypto::{calculate_key_id, sign_data, verify_signature, KeyManager};
+use crate::error::{Error, ErrorCode};
+use crate::pinning::{check_pinning, KeyPinStore};
+use crate::types::bundle::{BundleAuthority, SchemaPinTrustBundle};
+
+/// Bundle-distribution wire format version stamped on signed bundles.
+pub const BUNDLE_VERSION_SIGNED: &str = "1.4";
+
+/// Sentinel "domain" used to key bundle-authority pins in a [`KeyPinStore`].
+/// Authorities are pinned by `kid`, independent of any tool domain.
+pub const BUNDLE_AUTHORITY_PIN_DOMAIN: &str = "_bundle_authority";
+
+/// Build the canonical bytes that a bundle's signature covers: the bundle with
+/// its `signature` field forced to `""`, `schemapin-v1`-canonicalized.
+fn signing_bytes(bundle: &SchemaPinTrustBundle) -> Result<String, Error> {
+    let mut value = serde_json::to_value(bundle)?;
+    if let Value::Object(map) = &mut value {
+        map.insert("signature".to_string(), Value::String(String::new()));
+    }
+    Ok(canonicalize_schema(&value))
+}
+
+/// Sign a trust bundle with a bundle-authority key.
+///
+/// Stamps `bundle_authority` (derived public key + `kid`),
+/// `schemapin_bundle_version = "1.4"`, `signed_at`, and optional `expires_at`,
+/// then writes the base64 DER ECDSA P-256 `signature`. `signed_at` /
+/// `expires_at` are caller-supplied RFC 3339 strings (kept out of the core so
+/// signing is deterministic and cross-language testable).
+pub fn sign_trust_bundle(
+    bundle: &SchemaPinTrustBundle,
+    private_key_pem: &str,
+    kid: &str,
+    signed_at: &str,
+    expires_at: Option<&str>,
+) -> Result<SchemaPinTrustBundle, Error> {
+    let secret = KeyManager::load_private_key_pem(private_key_pem)?;
+    let public_key_pem = KeyManager::export_public_key_pem(&secret.public_key())?;
+
+    let mut signed = bundle.clone();
+    signed.schemapin_bundle_version = BUNDLE_VERSION_SIGNED.to_string();
+    signed.bundle_authority = Some(BundleAuthority {
+        kid: kid.to_string(),
+        public_key_pem,
+    });
+    signed.signed_at = Some(signed_at.to_string());
+    signed.expires_at = expires_at.map(|s| s.to_string());
+    signed.signature = None;
+
+    let canonical = signing_bytes(&signed)?;
+    signed.signature = Some(sign_data(private_key_pem, canonical.as_bytes())?);
+    Ok(signed)
+}
+
+/// Verify a signed trust bundle and TOFU-pin its authority key by `kid`.
+///
+/// Steps: require `bundle_authority` + `signature`; reject when `expires_at`
+/// is in the past; TOFU-pin the authority's key fingerprint by `kid` (mismatch
+/// → `KEY_PIN_MISMATCH`); verify the signature over the canonical bytes
+/// (failure → `SIGNATURE_INVALID`).
+pub fn verify_trust_bundle(
+    bundle: &SchemaPinTrustBundle,
+    authority_pin_store: &mut KeyPinStore,
+) -> Result<(), Error> {
+    let authority = bundle.bundle_authority.as_ref().ok_or(Error::Verification {
+        code: ErrorCode::BundleUnsigned,
+        message: "trust bundle has no bundle_authority".to_string(),
+    })?;
+    let signature = bundle.signature.as_ref().ok_or(Error::Verification {
+        code: ErrorCode::BundleUnsigned,
+        message: "trust bundle has no signature".to_string(),
+    })?;
+
+    if let Some(expires_at) = &bundle.expires_at {
+        let exp = chrono::DateTime::parse_from_rfc3339(expires_at).map_err(|e| {
+            Error::Verification {
+                code: ErrorCode::BundleExpired,
+                message: format!("unparseable expires_at '{}': {}", expires_at, e),
+            }
+        })?;
+        if chrono::Utc::now() > exp {
+            return Err(Error::Verification {
+                code: ErrorCode::BundleExpired,
+                message: format!("trust bundle expired at {}", expires_at),
+            });
+        }
+    }
+
+    let fingerprint = calculate_key_id(&authority.public_key_pem)?;
+    check_pinning(
+        authority_pin_store,
+        &authority.kid,
+        BUNDLE_AUTHORITY_PIN_DOMAIN,
+        &fingerprint,
+    )?;
+
+    let canonical = signing_bytes(bundle)?;
+    if verify_signature(&authority.public_key_pem, canonical.as_bytes(), signature)? {
+        Ok(())
+    } else {
+        Err(Error::Verification {
+            code: ErrorCode::SignatureInvalid,
+            message: "trust bundle signature does not verify".to_string(),
+        })
+    }
+}
+
+/// Merge trust bundles, deduplicating discovery + revocation documents by
+/// domain. When two bundles carry the same domain, the entry from the bundle
+/// with the newer timestamp (`signed_at`, else `created_at`) wins.
+///
+/// The result is an *unsigned* bundle (a merge cannot carry a single
+/// authority's signature) stamped `schemapin_bundle_version = "1.4"` with
+/// `created_at` set to the newest source timestamp. Re-sign it with
+/// [`sign_trust_bundle`] before redistribution.
+pub fn merge_trust_bundles(bundles: &[SchemaPinTrustBundle]) -> SchemaPinTrustBundle {
+    use std::collections::HashMap;
+
+    // domain -> (timestamp, document)
+    let mut docs: HashMap<String, (String, _)> = HashMap::new();
+    let mut revs: HashMap<String, (String, _)> = HashMap::new();
+    let mut newest_ts = String::new();
+
+    for b in bundles {
+        let ts = b
+            .signed_at
+            .clone()
+            .unwrap_or_else(|| b.created_at.clone());
+        if ts > newest_ts {
+            newest_ts = ts.clone();
+        }
+        for d in &b.documents {
+            match docs.get(&d.domain) {
+                Some((existing_ts, _)) if *existing_ts >= ts => {}
+                _ => {
+                    docs.insert(d.domain.clone(), (ts.clone(), d.clone()));
+                }
+            }
+        }
+        for r in &b.revocations {
+            match revs.get(&r.domain) {
+                Some((existing_ts, _)) if *existing_ts >= ts => {}
+                _ => {
+                    revs.insert(r.domain.clone(), (ts.clone(), r.clone()));
+                }
+            }
+        }
+    }
+
+    let mut documents: Vec<_> = docs.into_values().map(|(_, d)| d).collect();
+    documents.sort_by(|a, b| a.domain.cmp(&b.domain));
+    let mut revocations: Vec<_> = revs.into_values().map(|(_, r)| r).collect();
+    revocations.sort_by(|a, b| a.domain.cmp(&b.domain));
+
+    SchemaPinTrustBundle {
+        schemapin_bundle_version: BUNDLE_VERSION_SIGNED.to_string(),
+        created_at: newest_ts,
+        documents,
+        revocations,
+        ..Default::default()
+    }
+}
+
+/// Build a `schemapin/trustBundle` JSON-RPC request. `domain` optionally scopes
+/// the request to a single provider; omit for "send your whole bundle".
+pub fn build_trust_bundle_request(domain: Option<&str>, id: Value) -> Value {
+    let params = match domain {
+        Some(d) => json!({ "domain": d }),
+        None => json!({}),
+    };
+    json!({
+        "jsonrpc": "2.0",
+        "method": "schemapin/trustBundle",
+        "params": params,
+        "id": id,
+    })
+}
+
+/// Build a `schemapin/trustBundle` JSON-RPC response carrying a signed bundle.
+pub fn build_trust_bundle_response(
+    bundle: &SchemaPinTrustBundle,
+    id: Value,
+) -> Result<Value, Error> {
+    Ok(json!({
+        "jsonrpc": "2.0",
+        "result": { "bundle": serde_json::to_value(bundle)? },
+        "id": id,
+    }))
+}
+
+/// Extract the bundle from a `schemapin/trustBundle` JSON-RPC response.
+pub fn parse_trust_bundle_response(response: &Value) -> Result<SchemaPinTrustBundle, Error> {
+    let bundle = response
+        .get("result")
+        .and_then(|r| r.get("bundle"))
+        .ok_or(Error::Verification {
+            code: ErrorCode::DiscoveryInvalid,
+            message: "JSON-RPC response missing result.bundle".to_string(),
+        })?;
+    Ok(serde_json::from_value(bundle.clone())?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::generate_key_pair;
+    use crate::types::bundle::BundledDiscovery;
+    use crate::types::discovery::WellKnownResponse;
+
+    fn make_bundle(domain: &str, created_at: &str) -> SchemaPinTrustBundle {
+        SchemaPinTrustBundle {
+            schemapin_bundle_version: "1.2".to_string(),
+            created_at: created_at.to_string(),
+            documents: vec![BundledDiscovery {
+                domain: domain.to_string(),
+                well_known: WellKnownResponse {
+                    schema_version: "1.2".to_string(),
+                    developer_name: Some("Example".to_string()),
+                    public_key_pem: "-----BEGIN PUBLIC KEY-----\nx\n-----END PUBLIC KEY-----"
+                        .to_string(),
+                    revoked_keys: vec![],
+                    contact: None,
+                    revocation_endpoint: None,
+                },
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_sign_verify_roundtrip() {
+        let kp = generate_key_pair().unwrap();
+        let bundle = make_bundle("example.com", "2026-05-15T00:00:00Z");
+        let signed = sign_trust_bundle(
+            &bundle,
+            &kp.private_key_pem,
+            "auth-2026-05",
+            "2026-05-15T00:00:00Z",
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(signed.schemapin_bundle_version, "1.4");
+        assert!(signed.signature.is_some());
+        assert_eq!(signed.bundle_authority.as_ref().unwrap().kid, "auth-2026-05");
+
+        let mut store = KeyPinStore::new();
+        verify_trust_bundle(&signed, &mut store).unwrap();
+    }
+
+    #[test]
+    fn test_tampered_bundle_fails() {
+        let kp = generate_key_pair().unwrap();
+        let bundle = make_bundle("example.com", "2026-05-15T00:00:00Z");
+        let mut signed = sign_trust_bundle(
+            &bundle,
+            &kp.private_key_pem,
+            "auth",
+            "2026-05-15T00:00:00Z",
+            None,
+        )
+        .unwrap();
+        // Mutate a signed field.
+        signed.documents[0].domain = "evil.com".to_string();
+
+        let mut store = KeyPinStore::new();
+        let err = verify_trust_bundle(&signed, &mut store).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::Verification {
+                code: ErrorCode::SignatureInvalid,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_unsigned_bundle_rejected() {
+        let bundle = make_bundle("example.com", "2026-05-15T00:00:00Z");
+        let mut store = KeyPinStore::new();
+        let err = verify_trust_bundle(&bundle, &mut store).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::Verification {
+                code: ErrorCode::BundleUnsigned,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_expired_bundle_rejected() {
+        let kp = generate_key_pair().unwrap();
+        let bundle = make_bundle("example.com", "2020-01-01T00:00:00Z");
+        let signed = sign_trust_bundle(
+            &bundle,
+            &kp.private_key_pem,
+            "auth",
+            "2020-01-01T00:00:00Z",
+            Some("2020-02-01T00:00:00Z"),
+        )
+        .unwrap();
+        let mut store = KeyPinStore::new();
+        let err = verify_trust_bundle(&signed, &mut store).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::Verification {
+                code: ErrorCode::BundleExpired,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_authority_tofu_mismatch() {
+        let kp1 = generate_key_pair().unwrap();
+        let kp2 = generate_key_pair().unwrap();
+        let bundle = make_bundle("example.com", "2026-05-15T00:00:00Z");
+
+        let signed1 = sign_trust_bundle(
+            &bundle,
+            &kp1.private_key_pem,
+            "auth",
+            "2026-05-15T00:00:00Z",
+            None,
+        )
+        .unwrap();
+        // Different key, SAME kid → impersonation attempt.
+        let signed2 = sign_trust_bundle(
+            &bundle,
+            &kp2.private_key_pem,
+            "auth",
+            "2026-05-16T00:00:00Z",
+            None,
+        )
+        .unwrap();
+
+        let mut store = KeyPinStore::new();
+        verify_trust_bundle(&signed1, &mut store).unwrap(); // pins kp1
+        let err = verify_trust_bundle(&signed2, &mut store).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::Verification {
+                code: ErrorCode::KeyPinMismatch,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_merge_newest_wins() {
+        let mut older = make_bundle("example.com", "2026-01-01T00:00:00Z");
+        older.documents[0].well_known.developer_name = Some("Old".to_string());
+        let mut newer = make_bundle("example.com", "2026-05-01T00:00:00Z");
+        newer.documents[0].well_known.developer_name = Some("New".to_string());
+        let other = make_bundle("other.com", "2026-03-01T00:00:00Z");
+
+        let merged = merge_trust_bundles(&[older, newer, other]);
+        assert_eq!(merged.documents.len(), 2);
+        let ex = merged
+            .documents
+            .iter()
+            .find(|d| d.domain == "example.com")
+            .unwrap();
+        assert_eq!(ex.well_known.developer_name.as_deref(), Some("New"));
+        assert_eq!(merged.created_at, "2026-05-01T00:00:00Z");
+    }
+
+    #[test]
+    fn test_merge_signed_at_beats_created_at() {
+        // A bundle signed later (signed_at) should win even if created_at is older.
+        let mut a = make_bundle("example.com", "2026-01-01T00:00:00Z");
+        a.signed_at = Some("2026-09-01T00:00:00Z".to_string());
+        a.documents[0].well_known.developer_name = Some("Signed-late".to_string());
+        let mut b = make_bundle("example.com", "2026-06-01T00:00:00Z");
+        b.documents[0].well_known.developer_name = Some("Created-mid".to_string());
+
+        let merged = merge_trust_bundles(&[b, a]);
+        let ex = &merged.documents[0];
+        assert_eq!(ex.well_known.developer_name.as_deref(), Some("Signed-late"));
+    }
+
+    #[test]
+    fn test_jsonrpc_envelope_roundtrip() {
+        let kp = generate_key_pair().unwrap();
+        let bundle = make_bundle("example.com", "2026-05-15T00:00:00Z");
+        let signed = sign_trust_bundle(
+            &bundle,
+            &kp.private_key_pem,
+            "auth",
+            "2026-05-15T00:00:00Z",
+            None,
+        )
+        .unwrap();
+
+        let req = build_trust_bundle_request(Some("example.com"), json!(1));
+        assert_eq!(req["method"], "schemapin/trustBundle");
+        assert_eq!(req["params"]["domain"], "example.com");
+
+        let resp = build_trust_bundle_response(&signed, json!(1)).unwrap();
+        let parsed = parse_trust_bundle_response(&resp).unwrap();
+        assert_eq!(parsed, signed);
+
+        // And the parsed bundle still verifies.
+        let mut store = KeyPinStore::new();
+        verify_trust_bundle(&parsed, &mut store).unwrap();
+    }
+}

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -91,6 +91,14 @@ pub enum ErrorCode {
     /// empty-list-equals-unrestricted convention).
     #[serde(rename = "A2A_SCOPE_VIOLATION")]
     A2aScopeViolation,
+    /// (v1.4) A trust bundle was passed to `verify_trust_bundle` without a
+    /// `bundle_authority` / `signature` pair. Bundle distribution requires a
+    /// signed bundle.
+    #[serde(rename = "BUNDLE_UNSIGNED")]
+    BundleUnsigned,
+    /// (v1.4) A signed trust bundle's `expires_at` is in the past.
+    #[serde(rename = "BUNDLE_EXPIRED")]
+    BundleExpired,
 }
 
 impl std::fmt::Display for ErrorCode {
@@ -106,6 +114,8 @@ impl std::fmt::Display for ErrorCode {
             ErrorCode::SchemaCanonicalizationFailed => "SCHEMA_CANONICALIZATION_FAILED",
             ErrorCode::CanonicalizationUnsupported => "CANONICALIZATION_UNSUPPORTED",
             ErrorCode::A2aScopeViolation => "A2A_SCOPE_VIOLATION",
+            ErrorCode::BundleUnsigned => "BUNDLE_UNSIGNED",
+            ErrorCode::BundleExpired => "BUNDLE_EXPIRED",
         };
         write!(f, "{}", s)
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -68,6 +68,7 @@ pub mod core;
 pub mod crypto;
 
 // New modules (v1.2.0)
+pub mod bundle;
 pub mod canonicalize;
 pub mod discovery;
 pub mod error;

--- a/rust/src/resolver.rs
+++ b/rust/src/resolver.rs
@@ -257,6 +257,7 @@ mod tests {
                 ),
             }],
             revocations: vec![],
+            ..Default::default()
         }
     }
 

--- a/rust/src/skill.rs
+++ b/rust/src/skill.rs
@@ -1106,6 +1106,7 @@ mod tests {
                 well_known: discovery,
             }],
             revocations: vec![],
+            ..Default::default()
         };
         let resolver = TrustBundleResolver::new(&bundle);
         let mut pin_store = KeyPinStore::new();

--- a/rust/src/types/bundle.rs
+++ b/rust/src/types/bundle.rs
@@ -4,13 +4,40 @@ use super::discovery::WellKnownResponse;
 use super::revocation::RevocationDocument;
 
 /// A pre-shared collection of discovery and revocation documents for offline verification.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+///
+/// v1.4 adds optional distribution fields (`bundle_authority`, `signed_at`,
+/// `expires_at`, `signature`) so bundles can be signed by a bundle authority and
+/// safely exchanged between agents over A2A. See [`crate::bundle`] for the
+/// sign / verify / merge operations.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SchemaPinTrustBundle {
     pub schemapin_bundle_version: String,
     pub created_at: String,
     pub documents: Vec<BundledDiscovery>,
     #[serde(default)]
     pub revocations: Vec<RevocationDocument>,
+    /// (v1.4) The authority that signed this bundle. Present on signed bundles.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bundle_authority: Option<BundleAuthority>,
+    /// (v1.4) RFC 3339 timestamp the bundle was signed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signed_at: Option<String>,
+    /// (v1.4) Optional RFC 3339 expiry; verifiers reject the bundle past this.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+    /// (v1.4) Base64 DER ECDSA P-256 signature over the canonical bundle bytes
+    /// (`schemapin-v1` canonicalization with this field set to `""`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
+}
+
+/// (v1.4) Identifies and carries the public key of the authority that signed a
+/// trust bundle. TOFU-pinned by `kid` on first use (see
+/// [`crate::bundle::verify_trust_bundle`]).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BundleAuthority {
+    pub kid: String,
+    pub public_key_pem: String,
 }
 
 /// A discovery document bundled with its domain.
@@ -29,6 +56,10 @@ impl SchemaPinTrustBundle {
             created_at: created_at.to_string(),
             documents: vec![],
             revocations: vec![],
+            bundle_authority: None,
+            signed_at: None,
+            expires_at: None,
+            signature: None,
         }
     }
 
@@ -64,6 +95,7 @@ mod tests {
                 },
             }],
             revocations: vec![],
+            ..Default::default()
         }
     }
 

--- a/rust/src/verification.rs
+++ b/rust/src/verification.rs
@@ -679,6 +679,7 @@ mod tests {
                 well_known: f.discovery.clone(),
             }],
             revocations: vec![],
+            ..Default::default()
         };
         let resolver = TrustBundleResolver::new(&bundle);
         let mut pin_store = KeyPinStore::new();

--- a/rust/tests/cross_language_bundle.rs
+++ b/rust/tests/cross_language_bundle.rs
@@ -1,0 +1,15 @@
+//! Cross-language interop: verify the shared signed-bundle fixture that every
+//! SDK checks (see ../../tests/cross-language/README.md).
+
+use schemapin::bundle::verify_trust_bundle;
+use schemapin::pinning::KeyPinStore;
+use schemapin::types::bundle::SchemaPinTrustBundle;
+
+#[test]
+fn verifies_shared_signed_bundle_fixture() {
+    let json = std::fs::read_to_string("../tests/cross-language/signed_bundle.json")
+        .expect("fixture present");
+    let bundle: SchemaPinTrustBundle = serde_json::from_str(&json).unwrap();
+    let mut store = KeyPinStore::new();
+    verify_trust_bundle(&bundle, &mut store).expect("shared fixture must verify");
+}

--- a/tests/cross-language/README.md
+++ b/tests/cross-language/README.md
@@ -1,0 +1,11 @@
+# Cross-language interop fixtures
+
+`signed_bundle.json` is a v1.4 signed trust bundle produced by the Rust SDK
+(`sign_trust_bundle`), signed with `go/schemapin_private.pem` under the bundle
+authority kid `schemapin-bundle-authority-2026`. The authority public key is
+embedded in `bundle_authority.public_key_pem`, so the bundle is self-verifying.
+
+Each SDK has a test that loads this file and asserts `verify_trust_bundle`
+succeeds — proving the four SDKs agree on the bundle canonicalization and
+signing input. Regenerate by re-signing the same input if the wire format
+changes; all four SDK tests must still pass.

--- a/tests/cross-language/signed_bundle.json
+++ b/tests/cross-language/signed_bundle.json
@@ -1,0 +1,22 @@
+{
+  "schemapin_bundle_version": "1.4",
+  "created_at": "2026-05-15T00:00:00Z",
+  "documents": [
+    {
+      "domain": "example.com",
+      "schema_version": "1.4",
+      "developer_name": "Example Corp",
+      "public_key_pem": "-----BEGIN PUBLIC KEY-----\nMOCK\n-----END PUBLIC KEY-----",
+      "revoked_keys": [],
+      "contact": "security@example.com"
+    }
+  ],
+  "revocations": [],
+  "bundle_authority": {
+    "kid": "schemapin-bundle-authority-2026",
+    "public_key_pem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEg+aix0OfT3YmM1E+s98N6MoGP7C5\nCvO1BtD5K4KmJgv6N0B+LNtCf4Igu6Z94oyIoVHTUQ6i/cjQ1kzXx3Mv0w==\n-----END PUBLIC KEY-----\n"
+  },
+  "signed_at": "2026-05-15T00:00:00Z",
+  "expires_at": "2099-01-01T00:00:00Z",
+  "signature": "MEUCIQDyUMRPiPY6la8RTfOW7vRmOuIUkGMcrFjM4bAM/g9IRQIgQ3CRP/j/M1NrMzNU3s6f1S3kQm9h2a+ffLmfPHm9Uzs="
+}


### PR DESCRIPTION
Implements **roadmap item 6 — Trust Bundle Distribution for A2A Networks** across Rust, Python, JavaScript, and Go, and descopes items 7–8 to v1.5.

## What's new
Signed trust bundles can now be exchanged between agents over A2A without per-bundle out-of-band trust. A bundle authority signs a bundle; the receiver verifies it and TOFU-pins the authority key by `kid`.

- **Wire format**: optional `bundle_authority {kid, public_key_pem}`, `signed_at`, `expires_at`, `signature` on trust bundles. Signing covers the `schemapin-v1` canonicalization of the bundle with `signature` set to `""`.
- **Cross-language interop**: all four SDKs produce identical signing input. A Rust-signed bundle (`tests/cross-language/signed_bundle.json`) verifies in Python, JS, and Go — each SDK has a test asserting it.
- **Operations** (each SDK): `sign_trust_bundle`, `verify_trust_bundle`, `merge_trust_bundles` (dedup by domain, newest wins), and `schemapin/trustBundle` JSON-RPC envelope helpers.
- **New error codes**: `BUNDLE_UNSIGNED`, `BUNDLE_EXPIRED`.
- All four SDKs bumped to `1.4.0-alpha.4` (`1.4.0a4` Python).

## Design note
`bundle_authority` carries the key as `public_key_pem` (like discovery docs), not JWK — keeps the cross-language canonical signing input trivially identical. See the alpha.4 CHANGELOG entry.

## Descope
Items 7 (scan-aware signatures) and 8 (cross-agent schema cache) moved to v1.5.0 — both additive and independent, so they don't block the v1.4.0 GA. ROADMAP, CHANGELOG, spec §21, and docs updated.

## Tests
- Rust: 141 + cross-lang fixture + doctest, clippy clean
- Go: 14 packages ok, `go vet` clean
- Python: 214 passed, ruff clean
- JS: 190/190
